### PR TITLE
feat: Member Entity에 회원 상태 및 권한 필드 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -1,7 +1,11 @@
 package chocoteamteam.togather.entity;
 
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.Role;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -31,5 +35,13 @@ public class Member {
 
 	@Column(nullable = false)
 	private String profileImage;
+
+	@Enumerated(EnumType.STRING)
+	private MemberStatus status;
+
+	@Enumerated(EnumType.STRING)
+	private Role role;
+
+
 
 }

--- a/src/main/java/chocoteamteam/togather/type/MemberStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/MemberStatus.java
@@ -1,0 +1,6 @@
+package chocoteamteam.togather.type;
+
+public enum MemberStatus {
+	WAIT,PERMITTED,BANNED,WITHDRAWAL
+
+}

--- a/src/main/java/chocoteamteam/togather/type/Role.java
+++ b/src/main/java/chocoteamteam/togather/type/Role.java
@@ -1,0 +1,5 @@
+package chocoteamteam.togather.type;
+
+public enum Role {
+	ROLE_USER,ROLE_ADMIN
+}


### PR DESCRIPTION
**개요**

- 이슈번호 #1 
- Member Entity에 회원 상태 및 권한 필드 추가

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- Member Entity에 회원 상태 및 권한 필드를 enum 타입으로 추가하였습니다. 회원의 권한 설정이 Security 및 API 접근 처리에 필요하여 작성했습니다.

**Test**🧪
