### PR TITLE
feat: Spring Security에 JWT 인증 관리 기능 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/component/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtAccessDeniedHandler.java
@@ -1,5 +1,7 @@
 package chocoteamteam.togather.component.security;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import javax.servlet.ServletException;
@@ -29,7 +31,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
 	private void setResponse(HttpServletResponse response) {
 		response.setStatus(HttpStatus.FORBIDDEN.value());
-		response.setContentType("application/json");
+		response.setContentType(APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding("UTF-8");
 	}
 }

--- a/src/main/java/chocoteamteam/togather/component/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.component.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+		setResponse(response);
+
+		response.getWriter().write(objectMapper.writeValueAsString("권한이 없습니다."));
+		response.getWriter().flush();
+	}
+
+	private void setResponse(HttpServletResponse response) {
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+	}
+}

--- a/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationFilter.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationFilter.java
@@ -1,0 +1,92 @@
+package chocoteamteam.togather.component.security;
+
+import static chocoteamteam.togather.component.jwt.JwtUtils.BEARER_PREFIX;
+
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.exception.MemberStatusException;
+import chocoteamteam.togather.service.JwtService;
+import chocoteamteam.togather.type.MemberStatus;
+import java.io.IOException;
+import java.util.Arrays;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtService jwtService;
+
+	@Override
+	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		authenticate(request, getJwtFrom(request));
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void authenticate(HttpServletRequest request, String token) {
+		if (StringUtils.hasText(token)) {
+			try {
+
+				LoginMember loginMember = LoginMember.from(jwtService.parseAccessToken(token));
+
+				validateStatus(loginMember.getStatus());
+
+				saveLoginMemberInSecurityContext(loginMember);
+
+			} catch (RuntimeException e) {
+				SecurityContextHolder.clearContext();
+
+				request.setAttribute("errorMessage", e.getMessage());
+			}
+		}
+	}
+
+	private String getJwtFrom(HttpServletRequest request) {
+		String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(BEARER_PREFIX.length());
+		}
+
+		return null;
+	}
+
+	private void validateStatus(MemberStatus status) {
+		switch (status) {
+			case PERMITTED:
+				return;
+			case WAIT:
+				throw new MemberStatusException("대기중인 회원입니다.");
+			case BANNED:
+				throw new MemberStatusException("정지된 회원입니다.");
+			case WITHDRAWAL:
+				throw new MemberStatusException("탈퇴한 회원입니다.");
+			default:
+				throw new MemberStatusException("비정상적인 접근입니다.");
+		}
+	}
+
+	private static void saveLoginMemberInSecurityContext(LoginMember loginMember) {
+		JwtAuthenticationToken authentication = new JwtAuthenticationToken(
+			loginMember, "",
+			Arrays.asList(new SimpleGrantedAuthority(loginMember.getRole().name())));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+
+}

--- a/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationToken.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationToken.java
@@ -1,0 +1,30 @@
+package chocoteamteam.togather.component.security;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private Object principal;
+	private Object credentials;
+
+	public JwtAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		super.setAuthenticated(true);
+	}
+
+	@Override
+	public Object getCredentials() {
+		return this.credentials;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return this.principal;
+	}
+}

--- a/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -30,7 +31,7 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
 
 	private void setResponse(HttpServletResponse response) {
 		response.setStatus(HttpStatus.UNAUTHORIZED.value());
-		response.setContentType("application/json");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding("UTF-8");
 	}
 }

--- a/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
@@ -1,0 +1,36 @@
+package chocoteamteam.togather.component.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JwtEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+
+		setResponse(response);
+
+		response.getWriter().write(objectMapper.writeValueAsString(request.getAttribute("errorMessage")));
+		response.getWriter().flush();
+
+	}
+
+	private void setResponse(HttpServletResponse response) {
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+	}
+}

--- a/src/main/java/chocoteamteam/togather/config/SecurityConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/SecurityConfig.java
@@ -1,15 +1,29 @@
 package chocoteamteam.togather.config;
 
+import chocoteamteam.togather.component.security.JwtAccessDeniedHandler;
+import chocoteamteam.togather.component.security.JwtAuthenticationFilter;
+import chocoteamteam.togather.component.security.JwtEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @EnableGlobalMethodSecurity(securedEnabled = true,prePostEnabled = true)
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtEntryPoint jwtEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -18,7 +32,8 @@ public class SecurityConfig {
 
 		http.headers().frameOptions().disable();
 
-		http.cors().disable()
+		http.cors().configurationSource(corsConfigurationSource())
+			.and()
 			.httpBasic().disable()
 			.csrf().disable()
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -26,7 +41,28 @@ public class SecurityConfig {
 		http.formLogin().disable();
 		http.logout().disable();
 
+		http.exceptionHandling()
+			.authenticationEntryPoint(jwtEntryPoint)
+			.accessDeniedHandler(jwtAccessDeniedHandler);
+
+		http.addFilterBefore(jwtAuthenticationFilter,
+			UsernamePasswordAuthenticationFilter.class);
+
 		return http.build();
+	}
+
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.addAllowedOriginPattern("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/LoginMember.java
+++ b/src/main/java/chocoteamteam/togather/dto/LoginMember.java
@@ -1,0 +1,32 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.Role;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class LoginMember {
+
+	private Long id;
+	private String nickname;
+	private MemberStatus status;
+	private Role role;
+
+	public static LoginMember from(TokenMemberInfo info) {
+		return LoginMember.builder()
+			.id(info.getId())
+			.nickname(info.getNickname())
+			.status(MemberStatus.valueOf(info.getStatus()))
+			.role(Role.valueOf(info.getRole()))
+			.build();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/MemberStatusException.java
+++ b/src/main/java/chocoteamteam/togather/exception/MemberStatusException.java
@@ -1,0 +1,18 @@
+package chocoteamteam.togather.exception;
+
+
+public class MemberStatusException extends RuntimeException {
+
+	public MemberStatusException() {
+		super();
+	}
+
+	public MemberStatusException(String message) {
+		super(message);
+	}
+
+	public MemberStatusException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}


### PR DESCRIPTION
**개요**

- #1 
- Spring Security에 JWT 인증 기능 추가

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 헤더로 넘어오는 Access Token 인증을 위한 커스텀 AuthenticationFilter 추가
- JWT 인증 시 발생하는 오류를 처리하는 Custom Entry Point 작성
- API 요청 시 권한이 없을 경우, 오류를 처리하는 Custom AccessDeniedHandler 추가 
- Controller 단에서 로그인한 정보를 사용할 수 있도록 하는 DTO 추가

추가적으로 TokenMemberInfo가 있는데 LoginMember로 분리한 이유는 혹시나 후에 TokenMemberInfo의 내용이 변경될 경우, 유연성을 챙기기 위함이고, 이름을 통해 직관적으로 무슨 DTO인지 알기 쉽게하기 위해서 추가했습니다.


**Test**🧪
- 이 부분을 테스트 코드로 테스트하는 것은 후에 Controller 단 테스트 시에 시큐리티도 한꺼번에 하면 될 것 같아 보류해두었습니다.
- Postman을 이용한 권한 및 토큰 인증 테스트는 진행을 하였고 통과했습니다. 

**Others**
- 코드에 대한 궁금한 점이나 개선할 점이 있다면 편하게 말씀해주세요!
