### PR TITLE
feat: 회원가입 임시토큰 발급 및 파싱 기능 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/component/jwt/JwtUtils.java
+++ b/src/main/java/chocoteamteam/togather/component/jwt/JwtUtils.java
@@ -19,6 +19,7 @@ public class JwtUtils {
 	public static final String KEY_NICKNAME = "nickname";
 	public static final String KEY_STATUS = "status";
 	public static final String KEY_ROLES = "roles";
+	public static final String KEY_PROVIDER = "provider";
 
 	@Value("${jwt.secret-key.access}")
 	private String accessKey;
@@ -26,14 +27,22 @@ public class JwtUtils {
 	@Value("${jwt.secret-key.refresh}")
 	private String refreshKey;
 
+	@Value("${jwt.secret-key.signup}")
+	private String signupKey;
+
 	private Key encodedAccessKey;
 	private Key encodedRefreshKey;
+
+	private Key encodedSignupKey;
 
 	@Value("${jwt.expired-min.access}")
 	private int accessTokenExpiredMin;
 
 	@Value("${jwt.expired-min.refresh}")
 	private int refreshTokenExpiredMin;
+
+	@Value("${jwt.expired-min.signup}")
+	private int signupTokenExpiredMin;
 
 	@PostConstruct
 	private void init() {
@@ -42,6 +51,9 @@ public class JwtUtils {
 
 		encodedRefreshKey = Keys.hmacShaKeyFor(
 			Base64.getEncoder().encodeToString(refreshKey.getBytes()).getBytes());
+
+		encodedSignupKey = Keys.hmacShaKeyFor(
+			Base64.getEncoder().encodeToString(signupKey.getBytes()).getBytes());
 	}
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/SignUpTokenMemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUpTokenMemberInfo.java
@@ -1,0 +1,30 @@
+package chocoteamteam.togather.dto;
+
+
+import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_ID;
+import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_PROVIDER;
+
+import io.jsonwebtoken.Claims;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class SignUpTokenMemberInfo {
+
+	 private String email;
+	 private String provider;
+
+
+	public static SignUpTokenMemberInfo from(Claims claims) {
+		return SignUpTokenMemberInfo.builder()
+			.email(claims.get(KEY_ID, String.class))
+			.provider(claims.get(KEY_PROVIDER, String.class))
+			.build();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/InvalidSignUpTokenException.java
+++ b/src/main/java/chocoteamteam/togather/exception/InvalidSignUpTokenException.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.exception;
+
+
+public class InvalidSignUpTokenException extends RuntimeException {
+
+	public InvalidSignUpTokenException() {
+		super();
+	}
+
+	public InvalidSignUpTokenException(String message) {
+		super(message);
+	}
+
+	public InvalidSignUpTokenException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidSignUpTokenException(Throwable cause) {
+		super(cause);
+	}
+
+	protected InvalidSignUpTokenException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/chocoteamteam/togather/service/JwtService.java
+++ b/src/main/java/chocoteamteam/togather/service/JwtService.java
@@ -76,7 +76,7 @@ public class JwtService {
 			jwtParser.parseToken(accessToken, jwtUtils.getEncodedAccessKey()));
 	}
 
-	public String issueSignUpToken(String email, String provider) {
+	public String issueSignUpToken(@NonNull String email,@NonNull String provider) {
 		Claims claims = Jwts.claims();
 		claims.put(KEY_ID, email);
 		claims.put(KEY_PROVIDER, provider);
@@ -84,13 +84,13 @@ public class JwtService {
 		return jwtIssuer.issueToken(claims, jwtUtils.getEncodedSignupKey());
 	}
 
-	public SignUpTokenMemberInfo parseSignUpToken(String signUpToken) {
+	public SignUpTokenMemberInfo parseSignUpToken(@NonNull String signUpToken) {
 		Claims claims = jwtParser.parseToken(signUpToken, jwtUtils.getEncodedSignupKey());
 
 		if (!StringUtils.hasText(claims.get(KEY_PROVIDER, String.class))) {
 			throw new InvalidSignUpTokenException("유효한 회원가입 토큰이 아닙니다.");
 		}
-		
+
 		return SignUpTokenMemberInfo.from(claims);
 	}
 

--- a/src/main/java/chocoteamteam/togather/service/JwtService.java
+++ b/src/main/java/chocoteamteam/togather/service/JwtService.java
@@ -2,7 +2,10 @@ package chocoteamteam.togather.service;
 
 import static chocoteamteam.togather.component.jwt.JwtUtils.BEARER_PREFIX;
 import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_ID;
+import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_PROVIDER;
 
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.exception.InvalidSignUpTokenException;
 import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.component.jwt.JwtUtils;
 import chocoteamteam.togather.component.jwt.JwtIssuer;
@@ -11,10 +14,12 @@ import chocoteamteam.togather.dto.TokenMemberInfo;
 import chocoteamteam.togather.dto.Tokens;
 import chocoteamteam.togather.exception.InvalidRefreshTokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Service
@@ -71,5 +76,22 @@ public class JwtService {
 			jwtParser.parseToken(accessToken, jwtUtils.getEncodedAccessKey()));
 	}
 
+	public String issueSignUpToken(String email, String provider) {
+		Claims claims = Jwts.claims();
+		claims.put(KEY_ID, email);
+		claims.put(KEY_PROVIDER, provider);
+
+		return jwtIssuer.issueToken(claims, jwtUtils.getEncodedSignupKey());
+	}
+
+	public SignUpTokenMemberInfo parseSignUpToken(String signUpToken) {
+		Claims claims = jwtParser.parseToken(signUpToken, jwtUtils.getEncodedSignupKey());
+
+		if (!StringUtils.hasText(claims.get(KEY_PROVIDER, String.class))) {
+			throw new InvalidSignUpTokenException("유효한 회원가입 토큰이 아닙니다.");
+		}
+		
+		return SignUpTokenMemberInfo.from(claims);
+	}
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,8 @@ jwt:
   secret-key:
     access: TestSecretKey123asdasdadadwadwawdawdadwddwawdadwadawadwdwaawdawdwaddwadwawad
     refresh: TestRefreshKey2131asdsdasdwdwadawdawdwadwadawwadawdawdwadwadawdawdwadawdwad
+    signup: TestSignupKey123asdasdadadwadwawdvcbcvbcvbvcbcvbcvbcvcvbwdwaawdawdwaddwadwawad
   expired-min:
     access: 60
     refresh: 4320
+    signup: 5

--- a/src/test/java/chocoteamteam/togather/service/JwtServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/JwtServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.exception.InvalidSignUpTokenException;
 import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.component.jwt.JwtIssuer;
 import chocoteamteam.togather.component.jwt.JwtParser;
@@ -190,6 +192,79 @@ class JwtServiceTest {
 		//then
 		assertThatThrownBy(() -> jwtService.parseAccessToken(null))
 			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 발급 성공")
+	@Test
+	void issueSignUpToken_success() {
+		//given
+		given(jwtIssuer.issueToken(any(), any()))
+			.willReturn("signUpToken");
+
+		//when
+		String token = jwtService.issueSignUpToken("test@test.com", "kakao");
+
+		//then
+		assertThat(token).isEqualTo("signUpToken");
+	}
+
+	@DisplayName("SignUp Token 발급 실패 - 매개변수들이 null인 경우")
+	@Test
+	void issueSignUpToken_fail_parameterIsNull() {
+		//given
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.issueSignUpToken(null,"kakao"))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> jwtService.issueSignUpToken(null,null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> jwtService.issueSignUpToken("test",null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 파싱 성공")
+	@Test
+	void parseSignUpToken_success(){
+	    //given
+		Claims claims = Jwts.claims();
+
+		claims.put(KEY_ID, "test");
+		claims.put(KEY_PROVIDER, "kakao");
+
+		given(jwtParser.parseToken(any(), any()))
+			.willReturn(claims);
+
+	    //when
+		SignUpTokenMemberInfo info = jwtService.parseSignUpToken("signUpToken");
+
+		//then
+		assertThat(info.getEmail()).isEqualTo("test");
+		assertThat(info.getProvider()).isEqualTo("kakao");
+
+	}
+
+	@DisplayName("SignUp Token 파싱 실패 - 매개변수들이 null인 경우")
+	@Test
+	void parseSignUpToken_fail_parameterIsNull() {
+		//given
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.parseSignUpToken(null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 파싱 실패 - 회원가입 토큰이 아닌 경우")
+	@Test
+	void parseSignUpToken_fail_InvalidSignUpToken() {
+		//given
+		given(jwtParser.parseToken(any(), any()))
+			.willReturn(claims);
+
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.parseSignUpToken("singUpToken"))
+			.isInstanceOf(InvalidSignUpTokenException.class)
+			.hasMessage("유효한 회원가입 토큰이 아닙니다.");
 	}
 
 


### PR DESCRIPTION
**개요**
- #1 
- 회원가입 임시토큰 발급 및 파싱 기능 추가

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 회원가입 처리할 때 사용할 임시토큰 발급,파싱 기능을 JwtService에 추가하였습니다.

**Test**🧪
- 파라미터 Null 체크
- 회원가입 토큰이 아닌데 회원가입 토큰 파싱을 시도할 경우

**Others**
- 이번 PR은 develop으로 가는게 아닌 성현님께서 작업하고 계신 OAuth-signup 브랜치를 향한 PR 입니다.
- 필요한 부분이 있다고 하셔서 작업하게 되었습니다.
