### PR TITLE
feat: SNS 간편 로그인, 회원 가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
@@ -36,6 +36,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-inline:2.13.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/chocoteamteam/togather/component/jwt/JwtUtils.java
+++ b/src/main/java/chocoteamteam/togather/component/jwt/JwtUtils.java
@@ -19,6 +19,7 @@ public class JwtUtils {
 	public static final String KEY_NICKNAME = "nickname";
 	public static final String KEY_STATUS = "status";
 	public static final String KEY_ROLES = "roles";
+	public static final String KEY_PROVIDER = "provider";
 
 	@Value("${jwt.secret-key.access}")
 	private String accessKey;
@@ -26,14 +27,22 @@ public class JwtUtils {
 	@Value("${jwt.secret-key.refresh}")
 	private String refreshKey;
 
+	@Value("${jwt.secret-key.signup}")
+	private String signupKey;
+
 	private Key encodedAccessKey;
 	private Key encodedRefreshKey;
+
+	private Key encodedSignupKey;
 
 	@Value("${jwt.expired-min.access}")
 	private int accessTokenExpiredMin;
 
 	@Value("${jwt.expired-min.refresh}")
 	private int refreshTokenExpiredMin;
+
+	@Value("${jwt.expired-min.signup}")
+	private int signupTokenExpiredMin;
 
 	@PostConstruct
 	private void init() {
@@ -42,6 +51,9 @@ public class JwtUtils {
 
 		encodedRefreshKey = Keys.hmacShaKeyFor(
 			Base64.getEncoder().encodeToString(refreshKey.getBytes()).getBytes());
+
+		encodedSignupKey = Keys.hmacShaKeyFor(
+			Base64.getEncoder().encodeToString(signupKey.getBytes()).getBytes());
 	}
 
 }

--- a/src/main/java/chocoteamteam/togather/controller/OAuthController.java
+++ b/src/main/java/chocoteamteam/togather/controller/OAuthController.java
@@ -1,0 +1,43 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.LoginResponse;
+import chocoteamteam.togather.dto.SignUpControllerDto;
+import chocoteamteam.togather.dto.SignUpServiceDto;
+import chocoteamteam.togather.service.OAuthService;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/login")
+@RestController
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @PostMapping("/oauth/{provider}")
+    public LoginResponse login(@RequestParam String code, @PathVariable String provider) {
+        return oAuthService.login(code, provider);
+    }
+
+    @Valid
+    @PostMapping("/oauth/signup")
+    public SignUpControllerDto.Response signup(@RequestBody SignUpControllerDto.Request request,
+        @NotEmpty @RequestHeader(value = "signUpToken") String signUpToken) {
+        return oAuthService.signUp(SignUpServiceDto.builder()
+            .signUpToken(signUpToken)
+            .nickname(request.getNickname())
+            .profileImage(request.getProfileImage())
+            .techStackDtoList(request.getTechStackDtos())
+            .build());
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/controller/OAuthController.java
+++ b/src/main/java/chocoteamteam/togather/controller/OAuthController.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.LoginResponse;
+import chocoteamteam.togather.dto.SignUp;
+import chocoteamteam.togather.service.OAuthService;
+import javax.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/login")
+@RestController
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @PostMapping("/oauth/{provider}")
+    public LoginResponse login(@RequestParam String code, @PathVariable String provider) {
+        return oAuthService.login(code, provider);
+    }
+
+    @PostMapping("/oauth/signup")
+    public SignUp.Response signup(@RequestBody SignUp.Request request,
+        @NotEmpty @RequestHeader(value = "signUpToken") String signUpToken) {
+        return oAuthService.signUp(signUpToken, request.getNickname(), request.getProfileImage(),
+            request.getTechs());
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginResponse {
+
+    private String signUpToken;
+    private String accessToken;
+    private String refreshToken;
+    private String message;
+    private boolean loginResult;
+
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/MemberDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/MemberDto.java
@@ -1,0 +1,19 @@
+package chocoteamteam.togather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImage;
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/MemberTechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/MemberTechStackDto.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.TechCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MemberTechStackDto {
+
+    private Long id;
+    private String name;
+    private String image;
+    private TechCategory techCategory;
+    private MemberDto memberDto;
+    private TechStackDto techStackDto;
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/MemberTechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/MemberTechStackDto.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.TechCategory;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MemberTechStackDto {
+
+    private Long id;
+    private String name;
+    private String image;
+    private TechCategory techCategory;
+    private List<MemberDto> memberDtos;
+    private List<TechStackDto> techStackDtos;
+
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/OAuthTokenResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/OAuthTokenResponse.java
@@ -1,0 +1,21 @@
+package chocoteamteam.togather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OAuthTokenResponse {
+
+    private String id_token;
+    private String token_type;
+    private String access_token;
+    private String refresh_token;
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/SignUp.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUp.java
@@ -1,0 +1,36 @@
+package chocoteamteam.togather.dto;
+
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+public class SignUp {
+
+    @Setter
+    @Getter
+    @Builder
+    public static class Request {
+
+        @NotEmpty
+        private String nickname;
+        @NotEmpty
+        private String profileImage;
+        @NotEmpty
+        private List<TechStackDto> techs;
+
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class Response {
+
+        private String accessToken;
+        private String refreshToken;
+
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/SignUpControllerDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUpControllerDto.java
@@ -1,0 +1,36 @@
+package chocoteamteam.togather.dto;
+
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+public class SignUpControllerDto {
+
+    @Setter
+    @Getter
+    @Builder
+    public static class Request {
+
+        @NotEmpty
+        private String nickname;
+        @NotEmpty
+        private String profileImage;
+        @NotEmpty
+        private List<TechStackDto> techStackDtos;
+
+    }
+
+    @Setter
+    @Getter
+    @Builder
+    public static class Response {
+
+        private String accessToken;
+        private String refreshToken;
+
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/SignUpServiceDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUpServiceDto.java
@@ -1,0 +1,22 @@
+package chocoteamteam.togather.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignUpServiceDto {
+
+    private String signUpToken;
+    private String nickname;
+    private String profileImage;
+    private List<TechStackDto> techStackDtoList;
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/SignUpTokenMemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUpTokenMemberInfo.java
@@ -1,0 +1,30 @@
+package chocoteamteam.togather.dto;
+
+
+import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_ID;
+import static chocoteamteam.togather.component.jwt.JwtUtils.KEY_PROVIDER;
+
+import io.jsonwebtoken.Claims;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class SignUpTokenMemberInfo {
+
+	 private String email;
+	 private String provider;
+
+
+	public static SignUpTokenMemberInfo from(Claims claims) {
+		return SignUpTokenMemberInfo.builder()
+			.email(claims.get(KEY_ID, String.class))
+			.provider(claims.get(KEY_PROVIDER, String.class))
+			.build();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.TechCategory;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TechStackDto {
+
+    private Long id;
+    private String name;
+    private TechCategory category;
+    private String image;
+    private List<MemberTechStackDto> memberTechStackDtos;
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.TechCategory;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TechStackDto {
+
+    private Long id;
+    private String name;
+    private TechCategory category;
+    private String image;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -1,6 +1,7 @@
 package chocoteamteam.togather.entity;
 
 import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
 import chocoteamteam.togather.type.Role;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,25 +24,26 @@ import lombok.Setter;
 @Entity
 public class Member {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(nullable = false,unique = true)
-	private String email;
+    @Column(nullable = false, unique = true)
+    private String email;
 
-	@Column(nullable = false,unique = true)
-	private String nickname;
+    @Column(nullable = false, unique = true)
+    private String nickname;
 
-	@Column(nullable = false)
-	private String profileImage;
+    @Column(nullable = false)
+    private String profileImage;
 
-	@Enumerated(EnumType.STRING)
-	private MemberStatus status;
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
 
-	@Enumerated(EnumType.STRING)
-	private Role role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
-
+    @Enumerated(EnumType.STRING)
+    private ProviderType providerType;
 
 }

--- a/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
@@ -1,0 +1,33 @@
+package chocoteamteam.togather.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class MemberTechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "techStack_id")
+    private TechStack techStack;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
@@ -1,0 +1,34 @@
+package chocoteamteam.togather.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class MemberTechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private TechStack techStack;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/TechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/TechStack.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.entity;
+
+import chocoteamteam.togather.type.TechCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class TechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private TechCategory category;
+    private String image;
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/CustomOAuthException.java
+++ b/src/main/java/chocoteamteam/togather/exception/CustomOAuthException.java
@@ -1,0 +1,15 @@
+package chocoteamteam.togather.exception;
+
+public class CustomOAuthException extends RuntimeException {
+
+    public CustomOAuthException() {
+    }
+
+    public CustomOAuthException(String message) {
+        super(message);
+    }
+
+    public CustomOAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/chocoteamteam/togather/exception/InvalidSignUpTokenException.java
+++ b/src/main/java/chocoteamteam/togather/exception/InvalidSignUpTokenException.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.exception;
+
+
+public class InvalidSignUpTokenException extends RuntimeException {
+
+	public InvalidSignUpTokenException() {
+		super();
+	}
+
+	public InvalidSignUpTokenException(String message) {
+		super(message);
+	}
+
+	public InvalidSignUpTokenException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidSignUpTokenException(Throwable cause) {
+		super(cause);
+	}
+
+	protected InvalidSignUpTokenException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/chocoteamteam/togather/exception/TechStackException.java
+++ b/src/main/java/chocoteamteam/togather/exception/TechStackException.java
@@ -1,0 +1,15 @@
+package chocoteamteam.togather.exception;
+
+public class TechStackException extends RuntimeException {
+
+    public TechStackException() {
+    }
+
+    public TechStackException(String message) {
+        super(message);
+    }
+
+    public TechStackException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
@@ -1,0 +1,22 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+
+public class GithubOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public GithubOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class GithubOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public GithubOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    public Optional<String> getEmail() {
+        return Optional.of((String) attributes.get("email"));
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
@@ -1,0 +1,22 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+
+public class GoogleOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public GoogleOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class GoogleOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public GoogleOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    public Optional<String> getEmail() {
+        return Optional.of((String)attributes.get("email"));
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
@@ -1,0 +1,25 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class KakaoOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public KakaoOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return (String) properties.get("nickname");
+    }
+
+    public Optional<String> getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return Optional.of((String) kakaoAccount.get("email"));
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+
+public class KakaoOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public KakaoOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties == null ? null : (String) properties.get("nickname");
+    }
+
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount == null ? null : (String) kakaoAccount.get("email");
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class NaverOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public NaverOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("id");
+    }
+
+    public String getName() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("name");
+    }
+
+    public Optional<String> getEmail() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return Optional.of((String) response.get("email"));
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
@@ -1,0 +1,25 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+
+public class NaverOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    public NaverOAuth2MemberInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response == null ? null : (String)response.get("id");
+    }
+
+    public String getName() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response == null ? null : (String)response.get("name");
+    }
+
+    public String getEmail() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response == null ? null : (String)response.get("email");
+    }
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfo.java
@@ -1,0 +1,19 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+
+public abstract class OAuth2MemberInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2MemberInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfo.java
@@ -1,0 +1,20 @@
+package chocoteamteam.togather.oauth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class OAuth2MemberInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2MemberInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract Optional<String> getEmail();
+
+}

--- a/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfoFactory.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/OAuth2MemberInfoFactory.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.oauth2;
+
+import chocoteamteam.togather.exception.CustomOAuthException;
+import java.util.Map;
+
+public class OAuth2MemberInfoFactory {
+    public OAuth2MemberInfoFactory() {
+    }
+
+    public static OAuth2MemberInfo getOAuth2MemberInfo(String providerType, Map<String, Object> attributes) {
+        switch (providerType) {
+            case "GOOGLE":
+                return new GoogleOAuth2MemberInfo(attributes);
+            case "NAVER":
+                return new NaverOAuth2MemberInfo(attributes);
+            case "KAKAO":
+                return new KakaoOAuth2MemberInfo(attributes);
+            case "GITHUB":
+                return new GithubOAuth2MemberInfo(attributes);
+            default:
+                throw new CustomOAuthException("제공하지 않는 간편 로그인입니다.");
+        }
+    }
+}

--- a/src/main/java/chocoteamteam/togather/repository/MemberRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/MemberTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/MemberTechStackRepository.java
@@ -1,0 +1,8 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.MemberTechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTechStackRepository extends JpaRepository<MemberTechStack, Long> {
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/TechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/TechStackRepository.java
@@ -1,0 +1,7 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.TechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+}

--- a/src/main/java/chocoteamteam/togather/service/OAuthService.java
+++ b/src/main/java/chocoteamteam/togather/service/OAuthService.java
@@ -1,0 +1,187 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.LoginResponse;
+import chocoteamteam.togather.dto.OAuthTokenResponse;
+import chocoteamteam.togather.dto.SignUpControllerDto;
+import chocoteamteam.togather.dto.SignUpControllerDto.Response;
+import chocoteamteam.togather.dto.SignUpServiceDto;
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.dto.TokenMemberInfo;
+import chocoteamteam.togather.dto.Tokens;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.MemberTechStack;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.CustomOAuthException;
+import chocoteamteam.togather.exception.TechStackException;
+import chocoteamteam.togather.oauth2.OAuth2MemberInfo;
+import chocoteamteam.togather.oauth2.OAuth2MemberInfoFactory;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.LoginStatus;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+
+    private final MemberRepository memberRepository;
+    private final TechStackRepository techStackRepository;
+    private final MemberTechStackRepository memberTechStackRepository;
+    private final InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+    private final JwtService jwtService;
+
+    public LoginResponse login(String code, String providerType) {
+
+        ClientRegistration provider = inMemoryClientRegistrationRepository.findByRegistrationId(
+            providerType);
+
+        OAuthTokenResponse oAuthToken = getOAuth2Token(code, provider);
+
+        Map<String, Object> attributes = getAttributes(oAuthToken, provider);
+
+        OAuth2MemberInfo oAuth2MemberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(
+            providerType.toUpperCase(), attributes);
+
+        String email = oAuth2MemberInfo.getEmail()
+            .orElseThrow(() -> new CustomOAuthException("이메일을 찾을 수 없습니다."));
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isEmpty()) {
+            String signUpToken = jwtService.issueSignUpToken(email,
+                providerType.toUpperCase());
+            return LoginResponse.builder()
+                .signUpToken(signUpToken)
+                .message(LoginStatus.NEW.getMessage())
+                .loginResult(LoginStatus.NEW.isFoundMember())
+                .build();
+        }
+
+        Member member = optionalMember.get();
+
+        if (!member.getProviderType().toString().equals(providerType.toUpperCase())) {
+            throw new CustomOAuthException(member.getProviderType() + " 아이디로 로그인하시길 바랍니다.");
+        }
+
+        Tokens tokens = getTokens(member);
+        return LoginResponse.builder().accessToken(tokens.getAccessToken())
+            .refreshToken(tokens.getRefreshToken())
+            .message(LoginStatus.EXIST.getMessage())
+            .loginResult(LoginStatus.EXIST.isFoundMember()).build();
+    }
+
+    @Transactional
+    public SignUpControllerDto.Response signUp(SignUpServiceDto signUpServiceDto) {
+
+        SignUpTokenMemberInfo signUpTokenMemberInfo = jwtService.parseSignUpToken(
+            signUpServiceDto.getSignUpToken());
+
+        if (memberRepository.existsByNickname(signUpServiceDto.getNickname())) {
+            throw new CustomOAuthException("이미 존재하는 닉네임입니다.");
+        }
+
+        Member member = memberRepository.save(
+            Member.builder()
+                .email(signUpTokenMemberInfo.getEmail())
+                .nickname(signUpServiceDto.getNickname())
+                .profileImage(signUpServiceDto.getProfileImage())
+                .status(MemberStatus.PERMITTED)
+                .role(Role.ROLE_USER)
+                .providerType(ProviderType.valueOf(signUpTokenMemberInfo.getProvider()))
+                .build()
+        );
+
+        List<TechStack> techStacks = getTechsById(signUpServiceDto.getTechStackDtoList());
+        registerTechMembers(member, techStacks);
+
+        Tokens tokens = getTokens(member);
+        return Response.builder()
+            .accessToken(tokens.getAccessToken())
+            .refreshToken(tokens.getRefreshToken())
+            .build();
+    }
+
+    private Tokens getTokens(Member member) {
+        return jwtService.issueTokens(
+            TokenMemberInfo.builder().id(member.getId()).nickname(member.getNickname())
+                .role(member.getRole().toString()).status(member.getStatus().toString()).build());
+    }
+
+    private List<TechStack> getTechsById(List<TechStackDto> techStackDtos) {
+        List<Long> techIds = techStackDtos.stream().map(TechStackDto::getId)
+            .collect(Collectors.toList());
+        List<TechStack> techStacks = techStackRepository.findAllById(techIds);
+        if (techStacks.isEmpty()) {
+            throw new TechStackException("기술이 존재하지 않습니다.");
+        } else {
+            return techStacks;
+        }
+    }
+
+    private void registerTechMembers(Member member, List<TechStack> techStacks) {
+        for (TechStack techStack : techStacks) {
+            memberTechStackRepository.save(MemberTechStack.builder()
+                .member(member)
+                .techStack(techStack)
+                .build());
+        }
+    }
+
+    private MultiValueMap<String, String> tokenRequest(String code, ClientRegistration provider) {
+        LinkedMultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("code", code);
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_id", provider.getClientId());
+        formData.add("client_secret", provider.getClientSecret());
+        return formData;
+    }
+
+    private OAuthTokenResponse getOAuth2Token(String code, ClientRegistration provider) {
+        return WebClient.create()
+            .post()
+            .uri(provider.getProviderDetails().getTokenUri())
+            .headers(header -> {
+                header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+                header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+                header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+            })
+            .bodyValue(tokenRequest(code, provider))
+            .retrieve()
+            .bodyToMono(OAuthTokenResponse.class)
+            .block();
+    }
+
+    private Map<String, Object> getAttributes(OAuthTokenResponse oAuthToken,
+        ClientRegistration provider) {
+        return WebClient.create()
+            .get()
+            .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+            .headers(httpHeader -> httpHeader.setBearerAuth(oAuthToken.getAccess_token()))
+            .retrieve().bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+            })
+            .block();
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/service/OAuthService.java
+++ b/src/main/java/chocoteamteam/togather/service/OAuthService.java
@@ -1,0 +1,188 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.LoginResponse;
+import chocoteamteam.togather.dto.OAuthTokenResponse;
+import chocoteamteam.togather.dto.SignUp;
+import chocoteamteam.togather.dto.SignUp.Response;
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.dto.TokenMemberInfo;
+import chocoteamteam.togather.dto.Tokens;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.MemberTechStack;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.CustomOAuthException;
+import chocoteamteam.togather.exception.TechStackException;
+import chocoteamteam.togather.oauth2.OAuth2MemberInfo;
+import chocoteamteam.togather.oauth2.OAuth2MemberInfoFactory;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.LoginStatus;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+
+    private final MemberRepository memberRepository;
+    private final TechStackRepository techStackRepository;
+    private final MemberTechStackRepository memberTechStackRepository;
+    private final InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+    private final JwtService jwtService;
+
+    public LoginResponse login(String code, String providerType) {
+
+        ClientRegistration provider = inMemoryClientRegistrationRepository.findByRegistrationId(
+            providerType);
+
+        OAuthTokenResponse oAuthToken = getOAuth2Token(code, provider);
+
+        Map<String, Object> attributes = getAttributes(oAuthToken, provider);
+
+        OAuth2MemberInfo oAuth2MemberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(
+            providerType.toUpperCase(), attributes);
+
+        if (!StringUtils.hasText(oAuth2MemberInfo.getEmail())) {
+            throw new CustomOAuthException("이메일을 찾을 수 없습니다.");
+        }
+        Optional<Member> optionalMember = memberRepository.findByEmail(
+            oAuth2MemberInfo.getEmail());
+
+        if (optionalMember.isEmpty()) {
+            String signUpToken = jwtService.issueSignUpToken(oAuth2MemberInfo.getEmail(),
+                providerType.toUpperCase());
+            return LoginResponse.builder()
+                .signUpToken(signUpToken)
+                .message(LoginStatus.NEW_MEMBER.getMessage())
+                .loginResult(LoginStatus.NEW_MEMBER.isFoundMember())
+                .build();
+        }
+
+        Member member = optionalMember.get();
+
+        if (!member.getProviderType().toString().equals(providerType.toUpperCase())) {
+            throw new CustomOAuthException(member.getProviderType() + " 아이디로 로그인하시길 바랍니다.");
+        }
+
+        Tokens tokens = getTokens(member);
+        return LoginResponse.builder().accessToken(tokens.getAccessToken())
+            .refreshToken(tokens.getRefreshToken())
+            .message(LoginStatus.EXISTING_MEMBER.getMessage())
+            .loginResult(LoginStatus.EXISTING_MEMBER.isFoundMember()).build();
+    }
+
+    @Transactional
+    public SignUp.Response signUp(String signUpToken, String nickname, String profileImage,
+        List<TechStackDto> techStackDtos) {
+
+        SignUpTokenMemberInfo signUpTokenMemberInfo = jwtService.parseSignUpToken(signUpToken);
+
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new CustomOAuthException("이미 존재하는 닉네임입니다.");
+        }
+
+        Member member = memberRepository.save(
+            Member.builder()
+                .email(signUpTokenMemberInfo.getEmail())
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .status(MemberStatus.PERMITTED)
+                .role(Role.ROLE_USER)
+                .providerType(Enum.valueOf(ProviderType.class, signUpTokenMemberInfo.getProvider()))
+                .build()
+        );
+
+        List<TechStack> techStacks = getTechsById(techStackDtos);
+        registerTechMembers(member, techStacks);
+
+        Tokens tokens = getTokens(member);
+        return Response.builder()
+            .accessToken(tokens.getAccessToken())
+            .refreshToken(tokens.getRefreshToken())
+            .build();
+    }
+
+    private Tokens getTokens(Member member) {
+        return jwtService.issueTokens(
+            TokenMemberInfo.builder().id(member.getId()).nickname(member.getNickname())
+                .role(member.getRole().toString()).status(member.getStatus().toString()).build());
+    }
+
+    private List<TechStack> getTechsById(List<TechStackDto> techStackDtos) {
+        List<Long> techIds = techStackDtos.stream().map(TechStackDto::getId)
+            .collect(Collectors.toList());
+        List<TechStack> techStacks = techStackRepository.findAllById(techIds);
+        if (techStacks.isEmpty()) {
+            throw new TechStackException("기술이 존재하지 않습니다.");
+        } else {
+            return techStacks;
+        }
+    }
+
+    private void registerTechMembers(Member member, List<TechStack> techStacks) {
+        for (TechStack techStack : techStacks) {
+            memberTechStackRepository.save(MemberTechStack.builder()
+                .member(member)
+                .techStack(techStack)
+                .build());
+        }
+    }
+
+    private MultiValueMap<String, String> tokenRequest(String code, ClientRegistration provider) {
+        LinkedMultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("code", code);
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_id", provider.getClientId());
+        formData.add("client_secret", provider.getClientSecret());
+        return formData;
+    }
+
+    private OAuthTokenResponse getOAuth2Token(String code, ClientRegistration provider) {
+        return WebClient.create()
+            .post()
+            .uri(provider.getProviderDetails().getTokenUri())
+            .headers(header -> {
+                header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+                header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+                header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+            })
+            .bodyValue(tokenRequest(code, provider))
+            .retrieve()
+            .bodyToMono(OAuthTokenResponse.class)
+            .block();
+    }
+
+    private Map<String, Object> getAttributes(OAuthTokenResponse oAuthToken,
+        ClientRegistration provider) {
+        return WebClient.create()
+            .get()
+            .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+            .headers(httpHeader -> httpHeader.setBearerAuth(oAuthToken.getAccess_token()))
+            .retrieve().bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+            })
+            .block();
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/type/LoginStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/LoginStatus.java
@@ -1,0 +1,15 @@
+package chocoteamteam.togather.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LoginStatus {
+
+    EXIST("기존 회원", true),
+    NEW("신규 회원", false);
+
+    private String message;
+    private boolean foundMember;
+}

--- a/src/main/java/chocoteamteam/togather/type/LoginStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/LoginStatus.java
@@ -1,0 +1,15 @@
+package chocoteamteam.togather.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LoginStatus {
+
+    EXISTING_MEMBER("기존 회원", true),
+    NEW_MEMBER("신규 회원", false);
+
+    private String message;
+    private boolean foundMember;
+}

--- a/src/main/java/chocoteamteam/togather/type/ProviderType.java
+++ b/src/main/java/chocoteamteam/togather/type/ProviderType.java
@@ -1,0 +1,10 @@
+package chocoteamteam.togather.type;
+
+public enum ProviderType {
+
+    GOOGLE,
+    NAVER,
+    KAKAO,
+    GITHUB,
+
+}

--- a/src/main/java/chocoteamteam/togather/type/TechCategory.java
+++ b/src/main/java/chocoteamteam/togather/type/TechCategory.java
@@ -1,0 +1,6 @@
+package chocoteamteam.togather.type;
+
+public enum TechCategory {
+    BACK_END,
+    FRONT_END,
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ spring:
     host: localhost
     port: 6379
 
+  profiles:
+    include: oauth
+
 jwt:
   secret-key:
     access: TestSecretKey123asdasdadadwadwawdawdadwddwawdadwadawadwdwaawdawdwaddwadwawad

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,8 @@ jwt:
   secret-key:
     access: TestSecretKey123asdasdadadwadwawdawdadwddwawdadwadawadwdwaawdawdwaddwadwawad
     refresh: TestRefreshKey2131asdsdasdwdwadawdawdwadwadawwadawdawdwadwadawdawdwadawdwad
+    signup: TestSignupKey123asdasdadadwadwawdvcbcvbcvbvcbcvbcvbcvcvbwdwaawdawdwaddwadwawad
   expired-min:
     access: 60
     refresh: 4320
+    signup: 5

--- a/src/test/java/chocoteamteam/togather/service/JwtServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/JwtServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.exception.InvalidSignUpTokenException;
 import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.component.jwt.JwtIssuer;
 import chocoteamteam.togather.component.jwt.JwtParser;
@@ -190,6 +192,79 @@ class JwtServiceTest {
 		//then
 		assertThatThrownBy(() -> jwtService.parseAccessToken(null))
 			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 발급 성공")
+	@Test
+	void issueSignUpToken_success() {
+		//given
+		given(jwtIssuer.issueToken(any(), any()))
+			.willReturn("signUpToken");
+
+		//when
+		String token = jwtService.issueSignUpToken("test@test.com", "kakao");
+
+		//then
+		assertThat(token).isEqualTo("signUpToken");
+	}
+
+	@DisplayName("SignUp Token 발급 실패 - 매개변수들이 null인 경우")
+	@Test
+	void issueSignUpToken_fail_parameterIsNull() {
+		//given
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.issueSignUpToken(null,"kakao"))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> jwtService.issueSignUpToken(null,null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> jwtService.issueSignUpToken("test",null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 파싱 성공")
+	@Test
+	void parseSignUpToken_success(){
+	    //given
+		Claims claims = Jwts.claims();
+
+		claims.put(KEY_ID, "test");
+		claims.put(KEY_PROVIDER, "kakao");
+
+		given(jwtParser.parseToken(any(), any()))
+			.willReturn(claims);
+
+	    //when
+		SignUpTokenMemberInfo info = jwtService.parseSignUpToken("signUpToken");
+
+		//then
+		assertThat(info.getEmail()).isEqualTo("test");
+		assertThat(info.getProvider()).isEqualTo("kakao");
+
+	}
+
+	@DisplayName("SignUp Token 파싱 실패 - 매개변수들이 null인 경우")
+	@Test
+	void parseSignUpToken_fail_parameterIsNull() {
+		//given
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.parseSignUpToken(null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("SignUp Token 파싱 실패 - 회원가입 토큰이 아닌 경우")
+	@Test
+	void parseSignUpToken_fail_InvalidSignUpToken() {
+		//given
+		given(jwtParser.parseToken(any(), any()))
+			.willReturn(claims);
+
+		//when
+		//then
+		assertThatThrownBy(() -> jwtService.parseSignUpToken("singUpToken"))
+			.isInstanceOf(InvalidSignUpTokenException.class)
+			.hasMessage("유효한 회원가입 토큰이 아닙니다.");
 	}
 
 

--- a/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
@@ -1,0 +1,150 @@
+package chocoteamteam.togather.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import chocoteamteam.togather.dto.SignUpControllerDto;
+import chocoteamteam.togather.dto.SignUpServiceDto;
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.dto.Tokens;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.CustomOAuthException;
+import chocoteamteam.togather.exception.TechStackException;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({MockitoExtension.class})
+class OAuthServiceTest {
+
+    @Mock
+    JwtService jwtService;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    TechStackRepository techStackRepository;
+    @Mock
+    MemberTechStackRepository memberTechStackRepository;
+
+    @InjectMocks
+    OAuthService oAuthService;
+
+    String signUpToken = "signToken";
+    String nickname = "name";
+    String profileImage = "image";
+    String accessToken = "12345";
+    String refreshToken = "54321";
+    String email = "test@test.com";
+    String provider = "GOOGLE";
+    List<TechStackDto> techStackDtos = new ArrayList(
+        List.of(TechStackDto.builder().id(1L).build()));
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void signUp_success() {
+        // given
+        given(memberRepository.save(any())).willReturn(Member.builder()
+            .id(1L)
+            .email(email)
+            .nickname("test")
+            .profileImage(profileImage)
+            .status(MemberStatus.PERMITTED)
+            .role(Role.ROLE_USER)
+            .providerType(ProviderType.GOOGLE)
+            .build()
+        );
+        given(techStackRepository.findAllById(any())).willReturn(
+            List.of(TechStack.builder().build()));
+        given(jwtService.parseSignUpToken(any())).willReturn(SignUpTokenMemberInfo.builder()
+            .email(email)
+            .provider(provider)
+            .build());
+        given(jwtService.issueTokens(any())).willReturn(Tokens.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build());
+        given(memberTechStackRepository.save(any())).willReturn(
+            chocoteamteam.togather.entity.MemberTechStack.builder().build());
+
+        // when
+        SignUpControllerDto.Response response = oAuthService.signUp(
+            SignUpServiceDto.builder()
+                .signUpToken(signUpToken)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .techStackDtoList(techStackDtos)
+                .build());
+
+        // then
+        Assertions.assertThat(response.getAccessToken()).isEqualTo(accessToken);
+        Assertions.assertThat(response.getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+    @DisplayName("회원 가입 실패 - 기술이 존재하지 않음")
+    @Test
+    void signUp_fail_not_found_techStack() {
+        // given
+        given(jwtService.parseSignUpToken(any())).willReturn(SignUpTokenMemberInfo
+            .builder()
+            .email("test")
+            .provider("GOOGLE")
+            .build());
+        given(memberRepository.save(any())).willReturn(Member.builder().build());
+
+        // when
+
+        // then
+        assertThatThrownBy(
+            () -> oAuthService.signUp(SignUpServiceDto.builder()
+                .signUpToken(signUpToken)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .techStackDtoList(techStackDtos)
+                .build()))
+            .isInstanceOf(TechStackException.class)
+            .hasMessage("기술이 존재하지 않습니다.");
+    }
+
+    @DisplayName("회원 가입 실패 - 이미 존재하는 닉네임")
+    @Test
+    void signUp_fail_exits_true_nickname() {
+        // given
+        given(memberRepository.existsByNickname(nickname)).willReturn(true);
+        given(jwtService.parseSignUpToken(any())).willReturn(
+            SignUpTokenMemberInfo
+                .builder()
+                .email(email)
+                .provider(provider)
+                .build()
+        );
+
+        // when
+
+        // then
+        assertThatThrownBy(
+            () -> oAuthService.signUp(SignUpServiceDto.builder()
+                .signUpToken(signUpToken)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .techStackDtoList(techStackDtos)
+                .build()))
+            .isInstanceOf(CustomOAuthException.class)
+            .hasMessage("이미 존재하는 닉네임입니다.");
+    }
+
+}

--- a/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
@@ -1,0 +1,134 @@
+package chocoteamteam.togather.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import chocoteamteam.togather.dto.SignUp;
+import chocoteamteam.togather.dto.SignUpTokenMemberInfo;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.dto.Tokens;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.CustomOAuthException;
+import chocoteamteam.togather.exception.TechStackException;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({MockitoExtension.class})
+class OAuthServiceTest {
+
+    @Mock
+    JwtService jwtService;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    TechStackRepository techStackRepository;
+    @Mock
+    MemberTechStackRepository memberTechStackRepository;
+
+    @InjectMocks
+    OAuthService oAuthService;
+
+    String signUpToken = "signToken";
+    String nickname = "name";
+    String profileImage = "image";
+    String accessToken = "12345";
+    String refreshToken = "54321";
+    String email = "test@test.com";
+    String provider = "GOOGLE";
+    List<TechStackDto> techStackDtos = new ArrayList(
+        List.of(TechStackDto.builder().id(1L).build()));
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void signUp_success() {
+        // given
+        given(memberRepository.save(any())).willReturn(Member.builder()
+            .id(1L)
+            .email(email)
+            .nickname("test")
+            .profileImage(profileImage)
+            .status(MemberStatus.PERMITTED)
+            .role(Role.ROLE_USER)
+            .providerType(ProviderType.GOOGLE)
+            .build()
+        );
+        given(techStackRepository.findAllById(any())).willReturn(
+            List.of(TechStack.builder().build()));
+        given(jwtService.parseSignUpToken(any())).willReturn(SignUpTokenMemberInfo.builder()
+            .email(email)
+            .provider(provider)
+            .build());
+        given(jwtService.issueTokens(any())).willReturn(Tokens.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build());
+        given(memberTechStackRepository.save(any())).willReturn(
+            chocoteamteam.togather.entity.MemberTechStack.builder().build());
+
+        // when
+        SignUp.Response response = oAuthService.signUp(signUpToken, nickname,
+            profileImage, techStackDtos);
+
+        // then
+        Assertions.assertThat(response.getAccessToken()).isEqualTo(accessToken);
+        Assertions.assertThat(response.getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+    @DisplayName("회원 가입 실패 - 기술이 존재하지 않음")
+    @Test
+    void signUp_fail_not_found_techStack() {
+        // given
+        given(jwtService.parseSignUpToken(any())).willReturn(SignUpTokenMemberInfo
+            .builder()
+            .email("test")
+            .provider("GOOGLE")
+            .build());
+        given(memberRepository.save(any())).willReturn(Member.builder().build());
+
+        // when
+
+        // then
+        assertThatThrownBy(
+            () -> oAuthService.signUp(signUpToken, nickname, profileImage, techStackDtos))
+            .isInstanceOf(TechStackException.class)
+            .hasMessage("기술이 존재하지 않습니다.");
+    }
+
+    @DisplayName("회원 가입 실패 - 이미 존재하는 닉네임")
+    @Test
+    void signUp_fail_exits_true_nickname() {
+        // given
+        given(memberRepository.existsByNickname(nickname)).willReturn(true);
+        given(jwtService.parseSignUpToken(any())).willReturn(
+            SignUpTokenMemberInfo
+                .builder()
+                .email(email)
+                .provider(provider)
+                .build()
+        );
+
+        // when
+
+        // then
+        assertThatThrownBy(
+            () -> oAuthService.signUp(signUpToken, nickname, profileImage, techStackDtos))
+            .isInstanceOf(CustomOAuthException.class)
+            .hasMessage("이미 존재하는 닉네임입니다.");
+    }
+
+}


### PR DESCRIPTION
**개요**

- #1
- Sns 간편 로그인과 회원가입 기능을 구현했습니다.

**타입** 

- [x]  feat : 새로운 기능 추가

**작업 사항**
- SNS 간편 로그인 : Authorization code를 이용해 accessToken과 유저 정보를 가져와 저장된 정보와 검증 후 로그인에 성공하면 JWT 토큰을 발급합니다.
- 회원 가입 : SNS 로그인 성공 후 신규 유저일 경우 발급받은 임시 회원가입을 위한 signUpToken, 기술 스택, 닉네임, 프로필 사진을 입력 받아 Db에 저장하고 JWT 토큰을 발급 합니다.

**Test**🧪

- SNS 간편 로그인 : postman을 이용해서 간단하게 각 provider마다 유저 정보를 정상적으로 가져오는지, 가져온 정보들로 Db에 저장된 유저 정보와 검증되는지 테스트 했습니다.
- 회원 가입 : 잘못된 기술 스택, 중복된 닉네임인지, 정상적으로 값이 들어왔을 경우 가입에 성공하는지 테스트 했습니다.

**Others - optional**
- 예외 처리에 대한 부분이 애매해서 어떻게 처리할 것인지 의논하면 좋을 것 같습니다.
- sns 간편 로그인에 대한 테스트 부분 중 실제 테스트 코드를 mokito와 spring boot test로 직접 주입해서 둘 다 해봤지만 결국 WebClient를 이용하기 때문에 authorization code를 받아와야만 했습니다. 혹시 다른 좋은 방법을 알고 계시다면 알려주시면 적극적으로 반영해보겠습니다!