### PR TITLE
feat: 프로젝트 모집 글 등록 기능 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/config/JpaAuditConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package chocoteamteam.togather.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditConfig {
+}

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -1,0 +1,29 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectDto;
+import chocoteamteam.togather.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+public class ProjectController {
+    private final ProjectService projectService;
+
+    // 나중에 memberId 받아오기
+    @PostMapping
+    public ResponseEntity<ProjectDto> createProject(
+            @RequestBody CreateProjectForm form
+    ) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(
+                projectService.createProject(memberId, form)
+        );
+    }
+}

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/projects")
@@ -19,7 +21,7 @@ public class ProjectController {
     // 나중에 memberId 받아오기
     @PostMapping
     public ResponseEntity<ProjectDto> createProject(
-            @RequestBody CreateProjectForm form
+            @Valid @RequestBody CreateProjectForm form
     ) {
         Long memberId = 1L;
         return ResponseEntity.ok(

--- a/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateProjectForm {
+    private String title;
+    private String content;
+    private Integer personnel;
+    private ProjectStatus status;
+    private String location;
+    private LocalDate deadline;
+    private List<Long> techStackIds;
+}

--- a/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -14,11 +16,20 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateProjectForm {
+    @NotNull
+    @NotBlank
     private String title;
+    @NotNull
+    @NotBlank
     private String content;
+    @NotNull
     private Integer personnel;
+    @NotNull
     private ProjectStatus status;
+    @NotNull
     private String location;
+    @NotNull
     private LocalDate deadline;
+    @NotNull
     private List<Long> techStackIds;
 }

--- a/src/main/java/chocoteamteam/togather/dto/ErrorResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.exception.ErrorCode;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+    private int status;
+    private ErrorCode errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/chocoteamteam/togather/dto/MemberDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.dto;
 
+import chocoteamteam.togather.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +17,12 @@ public class MemberDto {
     private String nickname;
     private String profileImage;
 
+    public static MemberDto from(Member member) {
+        return MemberDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImage(member.getProfileImage())
+                .build();
+    }
 }

--- a/src/main/java/chocoteamteam/togather/dto/ProjectDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectDto.java
@@ -1,0 +1,44 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectDto {
+    private Long id;
+    private MemberDto member;
+    private String title;
+    private String content;
+    private Integer personnel;
+    private ProjectStatus status;
+    private String location;
+    private LocalDate deadline;
+    private List<ProjectTechStackDto> projectTechStacks;
+
+    public static ProjectDto from(Project project) {
+        return ProjectDto.builder()
+                .id(project.getId())
+                .member(MemberDto.from(project.getMember()))
+                .title(project.getTitle())
+                .content(project.getContent())
+                .personnel(project.getPersonnel())
+                .status(project.getStatus())
+                .location(project.getLocation())
+                .deadline(project.getDeadline())
+                .projectTechStacks(project.getProjectTechStacks().stream()
+                        .map(ProjectTechStackDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/chocoteamteam/togather/dto/ProjectTechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectTechStackDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProjectTechStackDto {
-    Long id;
+    private Long id;
     private Long projectId;
     private TechStackDto techStack;
 

--- a/src/main/java/chocoteamteam/togather/dto/ProjectTechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectTechStackDto.java
@@ -1,0 +1,25 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.entity.ProjectTechStack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectTechStackDto {
+    Long id;
+    private Long projectId;
+    private TechStackDto techStack;
+
+    public static ProjectTechStackDto from(ProjectTechStack projectTechStack) {
+        return ProjectTechStackDto.builder()
+                .id(projectTechStack.getId())
+                .projectId(projectTechStack.getProject().getId())
+                .techStack(TechStackDto.from(projectTechStack.getTechStack()))
+                .build();
+    }
+}

--- a/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/TechStackDto.java
@@ -1,11 +1,8 @@
 package chocoteamteam.togather.dto;
 
+import chocoteamteam.togather.entity.TechStack;
 import chocoteamteam.togather.type.TechCategory;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @Builder
@@ -19,4 +16,12 @@ public class TechStackDto {
     private TechCategory category;
     private String image;
 
+    public static TechStackDto from(TechStack techStack) {
+        return TechStackDto.builder()
+                .id(techStack.getId())
+                .name(techStack.getName())
+                .category(techStack.getCategory())
+                .image(techStack.getImage())
+                .build();
+    }
 }

--- a/src/main/java/chocoteamteam/togather/entity/BaseTimeEntity.java
+++ b/src/main/java/chocoteamteam/togather/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package chocoteamteam.togather.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Entity
-public class Member {
+public class Member extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class MemberTechStack {
+public class MemberTechStack extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -20,7 +20,6 @@ public class Project extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
     private Member member;
 
     private String title;

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -35,4 +37,6 @@ public class Project extends BaseTimeEntity {
 
     private LocalDate deadline;
 
+    @OneToMany(mappedBy = "project")
+    private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
 }

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -1,0 +1,38 @@
+package chocoteamteam.togather.entity;
+
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Project extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    private Integer personnel;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectStatus status;
+
+    private String location;
+
+    private LocalDate deadline;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/ProjectTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/ProjectTechStack.java
@@ -8,23 +8,26 @@ import javax.persistence.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Entity
 @Table(uniqueConstraints = {
         @UniqueConstraint(name = "project_tech_stack_check",
                 columnNames = {"project_id", "tech_stack_id"})
 })
 public class ProjectTechStack extends BaseTimeEntity {
+
+    public ProjectTechStack(Project project, TechStack techStack) {
+        setProject(project);
+        this.techStack = techStack;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_id")
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "tech_stack_id")
     private TechStack techStack;
 
     public void setProject(Project project) {

--- a/src/main/java/chocoteamteam/togather/entity/ProjectTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/ProjectTechStack.java
@@ -1,0 +1,37 @@
+package chocoteamteam.togather.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "project_tech_stack_check",
+                columnNames = {"project_id", "tech_stack_id"})
+})
+public class ProjectTechStack extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tech_stack_id")
+    private TechStack techStack;
+
+    public void setProject(Project project) {
+        if (this.project != null) {
+            this.project.getProjectTechStacks().remove(this);
+        }
+        this.project = project;
+        project.getProjectTechStacks().add(this);
+    }
+}

--- a/src/main/java/chocoteamteam/togather/entity/TechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/TechStack.java
@@ -13,14 +13,13 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class TechStack {
-
+public class TechStack extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(nullable = false, unique = true)
     private String name;
     @Enumerated(EnumType.STRING)
     private TechCategory category;
     private String image;
-
 }

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package chocoteamteam.togather.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    NOT_MATCH_MEMBER_PROJECT(HttpStatus.BAD_REQUEST, "해당 게시글에 대한 권한이 없습니다"),
+    NOT_FOUND_TECH_STACK(HttpStatus.BAD_REQUEST, "해당 기술 스택을 찾을 수 없습니다"),
+    NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
+    NOT_FOUND_PROJECT(HttpStatus.BAD_REQUEST, "프로젝트를 찾을 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}

--- a/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package chocoteamteam.togather.exception;
+
+import chocoteamteam.togather.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ProjectException.class)
+    public ErrorResponse exceptionHandler(ProjectException e) {
+        log.error("{} is occured", e.getErrorCode());
+        return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+}

--- a/src/main/java/chocoteamteam/togather/exception/ProjectException.java
+++ b/src/main/java/chocoteamteam/togather/exception/ProjectException.java
@@ -1,0 +1,16 @@
+package chocoteamteam.togather.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ProjectException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final int status;
+    private final String errorMessage;
+
+    public ProjectException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.status = errorCode.getHttpStatus().value();
+        this.errorMessage = errorCode.getErrorMessage();
+    }
+}

--- a/src/main/java/chocoteamteam/togather/repository/ProjectRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
@@ -1,0 +1,7 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.ProjectTechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -16,8 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_MEMBER;
 import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_TECH_STACK;
@@ -50,21 +50,21 @@ public class ProjectService {
     }
 
     private List<TechStack> getTechStacks(List<Long> techStackIds) {
-        return techStackIds.stream()
-                .map(tid -> techStackRepository.findById(tid)
-                        .orElseThrow(() -> new ProjectException(NOT_FOUND_TECH_STACK)))
-                .collect(Collectors.toList());
+        List<TechStack> techStacks = techStackRepository.findAllById(techStackIds);
+
+        if (techStacks.size() != techStackIds.size()) {
+            throw new ProjectException(NOT_FOUND_TECH_STACK);
+        }
+
+        return techStacks;
     }
 
     private void saveProjectTechs(Project project, List<TechStack> techStacks) {
-        List<ProjectTechStack> projectTechStacks = techStacks.stream()
-                .map(tech -> ProjectTechStack.builder()
-                        .techStack(tech)
-                        .build()
-                ).collect(Collectors.toList());
 
-        projectTechStacks.forEach(pt -> pt.setProject(project));
+        List<ProjectTechStack> projectTechStacks = new ArrayList<>();
+        for (TechStack tech : techStacks) {
+            projectTechStacks.add(new ProjectTechStack(project, tech));
+        }
         projectTechStackRepository.saveAll(projectTechStacks);
     }
-
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -1,0 +1,70 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectDto;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.ProjectTechStack;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.ProjectTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_TECH_STACK;
+
+@RequiredArgsConstructor
+@Service
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+    private final MemberRepository memberRepository;
+    private final TechStackRepository techStackRepository;
+    private final ProjectTechStackRepository projectTechStackRepository;
+
+    @Transactional
+    public ProjectDto createProject(Long memberId, CreateProjectForm form) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(NOT_FOUND_MEMBER));
+        Project project = projectRepository.save(Project.builder()
+                .member(member)
+                .title(form.getTitle())
+                .content(form.getContent())
+                .personnel(form.getPersonnel())
+                .status(ProjectStatus.RECRUITING)
+                .location(form.getLocation())
+                .deadline(form.getDeadline())
+                .build());
+
+        saveProjectTechs(project, getTechStacks(form.getTechStackIds()));
+        return ProjectDto.from(project);
+    }
+
+    private List<TechStack> getTechStacks(List<Long> techStackIds) {
+        return techStackIds.stream()
+                .map(tid -> techStackRepository.findById(tid)
+                        .orElseThrow(() -> new ProjectException(NOT_FOUND_TECH_STACK)))
+                .collect(Collectors.toList());
+    }
+
+    private void saveProjectTechs(Project project, List<TechStack> techStacks) {
+        List<ProjectTechStack> projectTechStacks = techStacks.stream()
+                .map(tech -> ProjectTechStack.builder()
+                        .techStack(tech)
+                        .build()
+                ).collect(Collectors.toList());
+
+        projectTechStacks.forEach(pt -> pt.setProject(project));
+        projectTechStackRepository.saveAll(projectTechStacks);
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/type/ProjectStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/ProjectStatus.java
@@ -1,0 +1,5 @@
+package chocoteamteam.togather.type;
+
+public enum ProjectStatus {
+    RECRUITING, COMPLETED
+}

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +52,7 @@ class ProjectServiceTest {
 
     private Member member;
     private Project project;
-    private TechStack techStack;
+    private final List<TechStack> techStacks = new ArrayList<>();
 
     @BeforeEach
     void beforeEach() {
@@ -74,13 +75,14 @@ class ProjectServiceTest {
                 .deadline(LocalDate.of(2022, 9, 12))
                 .build();
 
-        techStack = TechStack.builder()
-                .id(9L)
-                .name("java")
-                .category(TechCategory.BACKEND)
-                .image("img_url")
-                .build();
-
+        for (int i = 0; i < 2; i++) {
+            techStacks.add(TechStack.builder()
+                    .id((long) +1)
+                    .name("java" + i)
+                    .category(TechCategory.BACKEND)
+                    .image("img_url" + i)
+                    .build());
+        }
     }
 
     @Test
@@ -93,8 +95,8 @@ class ProjectServiceTest {
         given(projectRepository.save(any()))
                 .willReturn(project);
 
-        given(techStackRepository.findById(anyLong()))
-                .willReturn(Optional.of(techStack));
+        given(techStackRepository.findAllById(any()))
+                .willReturn(techStacks);
 
         //when
         CreateProjectForm form = new CreateProjectForm(
@@ -118,8 +120,8 @@ class ProjectServiceTest {
         assertEquals(project.getLocation(), projectDto.getLocation());
         assertEquals(project.getDeadline(), projectDto.getDeadline());
         assertEquals(project.getId(), projectDto.getProjectTechStacks().get(1).getProjectId());
-        assertEquals(techStack.getName(), projectDto.getProjectTechStacks().get(0).getTechStack().getName());
-        assertEquals(form.getTechStackIds().size(), projectDto.getProjectTechStacks().size());
+        assertEquals(techStacks.get(0).getName(), projectDto.getProjectTechStacks().get(0).getTechStack().getName());
+        assertEquals(techStacks.size(), projectDto.getProjectTechStacks().size());
         verify(projectTechStackRepository, times(1)).saveAll(any());
     }
 
@@ -143,8 +145,8 @@ class ProjectServiceTest {
         given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.of(member));
 
-        given(techStackRepository.findById(anyLong()))
-                .willReturn(Optional.empty());
+        given(techStackRepository.findAllById(any()))
+                .willReturn(new ArrayList<>());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
                 () -> projectService.createProject(1L, new CreateProjectForm(

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -1,0 +1,162 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectDto;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.ProjectTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.ProjectStatus;
+import chocoteamteam.togather.type.TechCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private TechStackRepository techStackRepository;
+    @Mock
+    private ProjectTechStackRepository projectTechStackRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    private Member member;
+    private Project project;
+    private TechStack techStack;
+
+    @BeforeEach
+    void beforeEach() {
+        member = Member.builder()
+                .id(9L)
+                .email("togather@to.com")
+                .nickname("두개더")
+                .profileImage("img_url")
+                .build();
+
+
+        project = Project.builder()
+                .id(999L)
+                .member(member)
+                .title("제목999")
+                .content("내용999")
+                .personnel(10)
+                .status(ProjectStatus.RECRUITING)
+                .location("서울")
+                .deadline(LocalDate.of(2022, 9, 12))
+                .build();
+
+        techStack = TechStack.builder()
+                .id(9L)
+                .name("java")
+                .category(TechCategory.BACKEND)
+                .image("img_url")
+                .build();
+
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 성공")
+    void createProjectSuccess() {
+        //given
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member));
+
+        given(projectRepository.save(any()))
+                .willReturn(project);
+
+        given(techStackRepository.findById(anyLong()))
+                .willReturn(Optional.of(techStack));
+
+        //when
+        CreateProjectForm form = new CreateProjectForm(
+                "의미 없는 제목",
+                "의미 없는 내용",
+                1000,
+                ProjectStatus.RECRUITING,
+                "의미 없는 위치",
+                LocalDate.of(2050, 9, 13),
+                List.of(1000L, 1001L)
+        );
+        ProjectDto projectDto = projectService.createProject(8L, form);
+
+        //then
+        assertEquals(project.getId(), projectDto.getId());
+        assertEquals(member.getId(), projectDto.getMember().getId());
+        assertEquals(project.getTitle(), projectDto.getTitle());
+        assertEquals(project.getContent(), projectDto.getContent());
+        assertEquals(project.getPersonnel(), projectDto.getPersonnel());
+        assertEquals(project.getStatus(), projectDto.getStatus());
+        assertEquals(project.getLocation(), projectDto.getLocation());
+        assertEquals(project.getDeadline(), projectDto.getDeadline());
+        assertEquals(project.getId(), projectDto.getProjectTechStacks().get(1).getProjectId());
+        assertEquals(techStack.getName(), projectDto.getProjectTechStacks().get(0).getTechStack().getName());
+        assertEquals(form.getTechStackIds().size(), projectDto.getProjectTechStacks().size());
+        verify(projectTechStackRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 실패 - 해당 멤버 없음")
+    void createProject_NotFoundMember() {
+        //given
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> projectService.createProject(1L, new CreateProjectForm()));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("프로젝트 등록 실패 - 해당 기술 스택 없음")
+    void createProject_NotFoundTechStack() {
+        //given
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member));
+
+        given(techStackRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> projectService.createProject(1L, new CreateProjectForm(
+                        "제목888",
+                        "내용888",
+                        20,
+                        ProjectStatus.RECRUITING,
+                        "부산",
+                        LocalDate.of(2022, 9, 13),
+                        List.of(5L, 6L)
+                )));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_TECH_STACK, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
**개요**

- #5 
- 프로젝트 등록 기능 구현

**타입** 

- [x]  feat : 새로운 기능 추가

**작업 사항**
- 프로젝트 모집 글(Project), 모집 기술 스택(ProjectTechStack) 엔티티 생성
- 프로젝트와 기술 스택의 관계가 다대다라 모집 기술 스택 테이블을 만들어 다대일 관계로 풀고, 프로젝트와 모집 기술 스택은 프로젝트에서 기술 스택 정보를 담고 있어야 하는 상황이라 양방향 매핑을 했습니다

**Test**🧪

- 성공 : 필요한 값을 주었을 때 예상한 대로 잘 등록되는지 확인
- 실패 
    - 해당 멤버가 존재하지 않을 때
    - 해당 기술 스택이 존재하지 않을 때

**Others**
- 앞 부분에 프로젝트 등록과는 관련 없는 커밋이 들어갔습니다. 앞으로는 좀 더 주의해서 잘 분리하도록 하겠습니다!
- 멤버 아이디는 일단 임의로 설정해서 진행했습니다. 나중에 받아서 controller 수정과 함께 테스트 추가하겠습니다
- Exception을 임의로 만들어 진행했는데, 이 부분 얘기 나눠봐야 할 것 같습니다
