### PR TITLE
feat: 프로젝트 모집 글 수정 기능 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -2,13 +2,11 @@ package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.CreateProjectForm;
 import chocoteamteam.togather.dto.ProjectDto;
+import chocoteamteam.togather.dto.UpdateProjectForm;
 import chocoteamteam.togather.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -26,6 +24,17 @@ public class ProjectController {
         Long memberId = 1L;
         return ResponseEntity.ok(
                 projectService.createProject(memberId, form)
+        );
+    }
+
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ProjectDto> updateProject(
+            @PathVariable Long projectId,
+            @Valid @RequestBody UpdateProjectForm form
+    ) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(
+                projectService.updateProject(projectId, memberId, form)
         );
     }
 }

--- a/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/CreateProjectForm.java
@@ -16,10 +16,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateProjectForm {
-    @NotNull
+
     @NotBlank
     private String title;
-    @NotNull
     @NotBlank
     private String content;
     @NotNull

--- a/src/main/java/chocoteamteam/togather/dto/UpdateProjectForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/UpdateProjectForm.java
@@ -16,10 +16,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateProjectForm {
-    @NotNull
+
     @NotBlank
     private String title;
-    @NotNull
     @NotBlank
     private String content;
     @NotNull

--- a/src/main/java/chocoteamteam/togather/dto/UpdateProjectForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/UpdateProjectForm.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProjectForm {
+    @NotNull
+    @NotBlank
+    private String title;
+    @NotNull
+    @NotBlank
+    private String content;
+    @NotNull
+    private Integer personnel;
+    @NotNull
+    private ProjectStatus status;
+    @NotNull
+    private String location;
+    @NotNull
+    private LocalDate deadline;
+    @NotNull
+    private List<Long> techStackIds;
+}

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.entity;
 
+import chocoteamteam.togather.dto.UpdateProjectForm;
 import chocoteamteam.togather.type.ProjectStatus;
 import lombok.*;
 
@@ -38,4 +39,13 @@ public class Project extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "project")
     private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
+
+    public void update(UpdateProjectForm form) {
+        this.title = form.getTitle();
+        this.content = form.getContent();
+        this.personnel = form.getPersonnel();
+        this.status = form.getStatus();
+        this.location = form.getLocation();
+        this.deadline = form.getDeadline();
+    }
 }

--- a/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
@@ -4,4 +4,5 @@ import chocoteamteam.togather.entity.ProjectTechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
+    void deleteAllByProjectId(Long projectId);
 }


### PR DESCRIPTION
**개요**

- #5 
- 프로젝트 수정 기능 구현

**타입** 

- [x]  feat : 새로운 기능 추가

**작업 사항**
- 기술 스택을 포함한 프로젝트 모집 글 수정

**Test**🧪

- 성공 : 모집 기술 스택 삭제, 저장 명령만 잘 실행됐는지 간단히 확인
- 실패
    - 해당 멤버가 존재하지 않을 때
    - 해당 프로젝트가 존재하지 않을 때
    - 프로젝트 공고 글의 작성자와 넘겨받은 멤버가 다를 때
    - 해당 기술 스택이 없을 때

**Others**
- 수정 시 기술 스택 변경은 일단, 프로젝트가 기존에 가지고 있던 기술 스택 정보를 다 지우고 새로 받은 기술 스택 정보를 저장하는 방식으로 했습니다.  다른 방법이 더 괜찮은 것 같으면 편하게 말씀해주세요!