### PR TITLE
feat: 프로젝트 모집 글 조회 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.3'
     id 'io.spring.dependency-management' version '1.0.13.RELEASE'
     id 'java'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'chocoTeamTeam'
@@ -33,6 +40,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.7.3'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -44,4 +55,33 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+
+// * querydsl settings *
+// querydsl 사용할 경로 지정합니다. - build
+def querydslDir = "$buildDir/generated/'querydsl'"
+
+// JPA 사용여부 및 사용 경로 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+// build시 사용할 sourceSet 추가 설정
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+// querydsl 컴파일 시 사용할 옵션 설정
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+// querydsl이 compileClassPath를 상속하도록 설정
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/chocoteamteam/togather/config/QueryDslConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package chocoteamteam.togather.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectCondition;
 import chocoteamteam.togather.dto.ProjectDto;
 import chocoteamteam.togather.dto.UpdateProjectForm;
 import chocoteamteam.togather.service.ProjectService;
@@ -36,5 +37,10 @@ public class ProjectController {
         return ResponseEntity.ok(
                 projectService.updateProject(projectId, memberId, form)
         );
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getProjectList(@Valid ProjectCondition projectCondition) {
+        return ResponseEntity.ok(projectService.getProjectList(projectCondition));
     }
 }

--- a/src/main/java/chocoteamteam/togather/dto/ProjectCondition.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectCondition.java
@@ -1,0 +1,40 @@
+package chocoteamteam.togather.dto;
+
+
+import chocoteamteam.togather.type.ProjectStatus;
+import lombok.*;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectCondition {
+
+    /*  검색 키워드 - option
+     * */
+    private String title;
+    private String content;
+    private String author;
+
+    /*  필터링 키워드 - option
+     * */
+    private ProjectStatus projectStatus;
+    private List<Long> skillsId;
+
+    /*  반환 size - 필수
+     * */
+    @NotNull
+    @Min(1)
+    @Max(100)
+    private Long limit;
+
+    /*  페이지 번호 - option - default 0
+     * */
+    private long pageNumber;
+}

--- a/src/main/java/chocoteamteam/togather/dto/ProjectCondition.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectCondition.java
@@ -25,7 +25,7 @@ public class ProjectCondition {
     /*  필터링 키워드 - option
      * */
     private ProjectStatus projectStatus;
-    private List<Long> skillsId;
+    private List<Long> techStackIds;
 
     /*  반환 size - 필수
      * */

--- a/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleMemberDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleMemberDto.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.dto.queryDslSimpleDto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class SimpleMemberDto {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+
+    @QueryProjection
+    public SimpleMemberDto(Long id, String nickname, String profileImage) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+}

--- a/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleProjectDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleProjectDto.java
@@ -1,0 +1,39 @@
+package chocoteamteam.togather.dto.queryDslSimpleDto;
+
+
+import chocoteamteam.togather.type.ProjectStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SimpleProjectDto {
+    private Long id;
+    private SimpleMemberDto member;
+    private String title;
+    private Integer personnel;
+    private ProjectStatus status;
+    private LocalDate deadline;
+
+    private List<SimpleTechStackDto> techStacks;
+
+    /*  queryDsl 전용
+     * */
+    @QueryProjection
+    public SimpleProjectDto(Long id, SimpleMemberDto member, String title, Integer personnel, ProjectStatus status, LocalDate deadline,
+                            List<SimpleTechStackDto> techStacks) {
+        this.id = id;
+        this.member = member;
+        this.title = title;
+        this.personnel = personnel;
+        this.status = status;
+        this.deadline = deadline;
+        this.techStacks = techStacks;
+    }
+}

--- a/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleTechStackDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/queryDslSimpleDto/SimpleTechStackDto.java
@@ -1,0 +1,25 @@
+package chocoteamteam.togather.dto.queryDslSimpleDto;
+
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class SimpleTechStackDto {
+    private Long id;
+    private String name;
+    private String image;
+
+    @QueryProjection
+    public SimpleTechStackDto(Long id, String name, String image) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+    }
+}

--- a/src/main/java/chocoteamteam/togather/repository/ProjectRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectRepository.java
@@ -3,5 +3,5 @@ package chocoteamteam.togather.repository;
 import chocoteamteam.togather.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, QueryDslProjectRepository {
 }

--- a/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
@@ -1,0 +1,11 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.dto.ProjectCondition;
+import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
+
+import java.util.List;
+
+public interface QueryDslProjectRepository {
+    List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition);
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
@@ -1,0 +1,102 @@
+package chocoteamteam.togather.repository.impl;
+
+
+import chocoteamteam.togather.dto.ProjectCondition;
+import chocoteamteam.togather.dto.queryDslSimpleDto.QSimpleMemberDto;
+import chocoteamteam.togather.dto.queryDslSimpleDto.QSimpleProjectDto;
+import chocoteamteam.togather.dto.queryDslSimpleDto.QSimpleTechStackDto;
+import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
+import chocoteamteam.togather.repository.QueryDslProjectRepository;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static chocoteamteam.togather.entity.QMember.member;
+import static chocoteamteam.togather.entity.QProject.project;
+import static chocoteamteam.togather.entity.QProjectTechStack.projectTechStack;
+import static com.querydsl.core.group.GroupBy.list;
+
+@RequiredArgsConstructor
+@Repository
+public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition) {
+        List<Long> Ids = getMultiConditionSearchId(projectCondition);
+        if (Ids.size() == 0) {
+            return Collections.emptyList();
+        }
+
+        return new ArrayList<>(jpaQueryFactory
+                .from(project)
+                .where(project.id.in(Ids))
+                .innerJoin(project.projectTechStacks, projectTechStack)
+                .transform(GroupBy.groupBy(project.id)
+                        .as(new QSimpleProjectDto(
+                                project.id,
+                                new QSimpleMemberDto(
+                                        project.member.id,
+                                        project.member.nickname,
+                                        project.member.profileImage),
+                                project.title,
+                                project.personnel,
+                                project.status,
+                                project.deadline,
+                                list(new QSimpleTechStackDto(
+                                        projectTechStack.techStack.id,
+                                        projectTechStack.techStack.name,
+                                        projectTechStack.techStack.image))
+                        )))
+                .values());
+    }
+
+    /*
+     *   페이징
+     *   기술스택, 프로젝트상태, 필터링
+     *   제목, 내용, 글쓴이 검색
+     * */
+    private List<Long> getMultiConditionSearchId(ProjectCondition projectCondition) {
+        return jpaQueryFactory
+                .select(project.id)
+                .from(project)
+                .leftJoin(project.projectTechStacks, projectTechStack)
+                .leftJoin(project.member, member)
+                .where(filterProjectStatus(projectCondition),
+                        filterTechStacks(projectCondition),
+                        searchProjectContent(projectCondition),
+                        searchProjectTitle(projectCondition),
+                        searchUserName(projectCondition))
+                .distinct()
+                .limit(projectCondition.getLimit())
+                .offset(projectCondition.getPageNumber() * projectCondition.getLimit())
+                .fetch();
+    }
+
+    private BooleanExpression filterProjectStatus(ProjectCondition projectCondition) {
+        return projectCondition.getProjectStatus() == null ? null : project.status.eq(projectCondition.getProjectStatus());
+    }
+
+    private BooleanExpression filterTechStacks(ProjectCondition projectCondition) {
+        return projectCondition.getSkillsId() == null ? null : projectTechStack.techStack.id.in(projectCondition.getSkillsId());
+    }
+
+    private BooleanExpression searchProjectContent(ProjectCondition projectCondition) {
+        return projectCondition.getContent() == null ? null : project.content.contains(projectCondition.getContent());
+    }
+
+    private BooleanExpression searchProjectTitle(ProjectCondition projectCondition) {
+        return projectCondition.getTitle() == null ? null : project.title.contains(projectCondition.getTitle());
+    }
+
+    private BooleanExpression searchUserName(ProjectCondition projectCondition) {
+        return projectCondition.getAuthor() == null ? null : member.nickname.contains(projectCondition.getAuthor());
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
@@ -29,14 +29,14 @@ public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository 
 
     @Override
     public List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition) {
-        List<Long> Ids = getMultiConditionSearchId(projectCondition);
-        if (Ids.size() == 0) {
+        List<Long> projectIds = getMultiConditionSearchId(projectCondition);
+        if (projectIds.size() == 0) {
             return Collections.emptyList();
         }
 
         return new ArrayList<>(jpaQueryFactory
                 .from(project)
-                .where(project.id.in(Ids))
+                .where(project.id.in(projectIds))
                 .innerJoin(project.projectTechStacks, projectTechStack)
                 .transform(GroupBy.groupBy(project.id)
                         .as(new QSimpleProjectDto(
@@ -84,7 +84,7 @@ public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository 
     }
 
     private BooleanExpression filterTechStacks(ProjectCondition projectCondition) {
-        return projectCondition.getSkillsId() == null ? null : projectTechStack.techStack.id.in(projectCondition.getSkillsId());
+        return projectCondition.getTechStackIds() == null ? null : projectTechStack.techStack.id.in(projectCondition.getTechStackIds());
     }
 
     private BooleanExpression searchProjectContent(ProjectCondition projectCondition) {

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -1,8 +1,10 @@
 package chocoteamteam.togather.service;
 
 import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectCondition;
 import chocoteamteam.togather.dto.ProjectDto;
 import chocoteamteam.togather.dto.UpdateProjectForm;
+import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
 import chocoteamteam.togather.entity.ProjectTechStack;
@@ -89,5 +91,9 @@ public class ProjectService {
         project.getProjectTechStacks().clear();
         saveProjectTechs(project, getTechStacks(form.getTechStackIds()));
         return ProjectDto.from(project);
+    }
+
+    public List<SimpleProjectDto> getProjectList(ProjectCondition projectCondition) {
+        return projectRepository.findAllOptionAndSearch(projectCondition);
     }
 }

--- a/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
@@ -11,8 +11,10 @@ import chocoteamteam.togather.repository.ProjectRepository;
 import chocoteamteam.togather.repository.ProjectTechStackRepository;
 import chocoteamteam.togather.repository.TechStackRepository;
 import chocoteamteam.togather.type.ProjectStatus;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -24,6 +26,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Import(QueryDslTestConfig.class)
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
@@ -43,15 +46,8 @@ class QueryDslProjectRepositoryImplTest {
     @Autowired
     private TechStackRepository techStackRepository;
 
-    private static boolean alreadySetup;
-
-    @PostConstruct
+    @BeforeAll
     public void dataSetup() {
-        if (alreadySetup) { // 한 번만 실행
-            return;
-        }
-        alreadySetup = true;
-
         Member aMember = memberRepository.save(Member.builder().email("www.a.com").nickname("aaaa name").profileImage("image").build());
         Member bMember = memberRepository.save(Member.builder().email("www.b.com").nickname("bbbb name").profileImage("image").build());
         Member cMember = memberRepository.save(Member.builder().email("www.c.com").nickname("cccc name").profileImage("image").build());

--- a/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
@@ -221,7 +221,7 @@ class QueryDslProjectRepositoryImplTest {
 
         ProjectCondition projectCondition = ProjectCondition.builder()
                 .limit(TOTAL_DATA_SIZE)
-                .skillsId(List.of(react.getId(), spring.getId()))
+                .techStackIds(List.of(react.getId(), spring.getId()))
                 .build();
         //when
 
@@ -247,7 +247,7 @@ class QueryDslProjectRepositoryImplTest {
 
         ProjectCondition projectCondition = ProjectCondition.builder()
                 .limit(TOTAL_DATA_SIZE)
-                .skillsId(List.of(react.getId(), php.getId()))
+                .techStackIds(List.of(react.getId(), php.getId()))
                 .projectStatus(ProjectStatus.COMPLETED)
                 .title("cccc")
                 .build();

--- a/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
@@ -1,0 +1,262 @@
+package chocoteamteam.togather.repository.impl;
+
+import chocoteamteam.togather.dto.ProjectCondition;
+import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.ProjectTechStack;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.ProjectTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.ProjectStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+class QueryDslProjectRepositoryImplTest {
+    @Autowired
+    private QueryDslProjectRepositoryImpl queryDslProjectRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProjectTechStackRepository projectTechStackRepository;
+
+    @Autowired
+    private TechStackRepository techStackRepository;
+
+    private static boolean alreadySetup;
+
+    @PostConstruct
+    public void dataSetup() {
+        if (alreadySetup) { // 한 번만 실행
+            return;
+        }
+        alreadySetup = true;
+
+        Member aMember = memberRepository.save(Member.builder().email("www.a.com").nickname("aaaa name").profileImage("image").build());
+        Member bMember = memberRepository.save(Member.builder().email("www.b.com").nickname("bbbb name").profileImage("image").build());
+        Member cMember = memberRepository.save(Member.builder().email("www.c.com").nickname("cccc name").profileImage("image").build());
+
+        TechStack react = techStackRepository.save(TechStack.builder().name("react").build());
+        TechStack angular = techStackRepository.save(TechStack.builder().name("angular").build());
+        TechStack spring = techStackRepository.save(TechStack.builder().name("spring").build());
+        TechStack nodejs = techStackRepository.save(TechStack.builder().name("nodejs").build());
+        TechStack php = techStackRepository.save(TechStack.builder().name("php").build());
+
+        Project aProject = projectRepository.save(Project.builder().member(aMember)
+                .title("aaaa title").content("aaaa content").status(ProjectStatus.RECRUITING).build());
+        Project bProject = projectRepository.save(Project.builder().member(bMember)
+                .title("bbbb title").content("bbbb content").status(ProjectStatus.RECRUITING).build());
+        Project cProject = projectRepository.save(Project.builder().member(cMember)
+                .title("cccc title").content("cccc content").status(ProjectStatus.COMPLETED).build());
+        Project dProject = projectRepository.save(Project.builder().member(aMember)
+                .title("dddd title").content("dddd content").status(ProjectStatus.COMPLETED).build());
+
+
+        projectTechStackRepository.save(new ProjectTechStack(aProject, react))
+                .setProject(aProject);
+        projectTechStackRepository.save(new ProjectTechStack(aProject, spring))
+                .setProject(aProject);
+        projectTechStackRepository.save(new ProjectTechStack(aProject, nodejs))
+                .setProject(aProject);
+
+        projectTechStackRepository.save(new ProjectTechStack(bProject, react))
+                .setProject(bProject);
+        projectTechStackRepository.save(new ProjectTechStack(bProject, spring))
+                .setProject(bProject);
+        projectTechStackRepository.save(new ProjectTechStack(bProject, nodejs))
+                .setProject(bProject);
+
+        projectTechStackRepository.save(new ProjectTechStack(cProject, php))
+                .setProject(cProject);
+        projectTechStackRepository.save(new ProjectTechStack(cProject, react))
+                .setProject(cProject);
+
+        projectTechStackRepository.save(new ProjectTechStack(dProject, php))
+                .setProject(dProject);
+        projectTechStackRepository.save(new ProjectTechStack(dProject, angular))
+                .setProject(dProject);
+
+        projectRepository.save(aProject);
+        projectRepository.save(bProject);
+        projectRepository.save(cProject);
+        projectRepository.save(dProject);
+
+        System.out.println("-------------------- insert query close ----------------\n\n");
+    }
+
+    private final long TOTAL_DATA_SIZE = 4;
+
+    @Test
+    @DisplayName("아무 조건 없이 조회")
+    void noOption_search_test() {
+        //given
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(10L)
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertEquals(4, result.size());
+    }
+
+    @Test
+    @DisplayName("조회 페이징 테스트")
+    void noOption_paging_test() {
+        //given
+        long pageSize = 2L;
+        int pageNumber = 1;
+
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(pageSize)
+                .pageNumber(pageNumber)
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertEquals(2, result.size());
+
+        // 0 page = [1L, 2L] , 1 page = [3L, 4L]
+        assertEquals(3L, result.get(0).getId());
+        assertEquals(4L, result.get(1).getId());
+    }
+
+    @Test
+    @DisplayName("작성자 이름으로 검색")
+    void author_search() {
+        //given
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .author("cc")
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertTrue(result.size() > 0);
+        for (SimpleProjectDto simpleProjectDto : result) {
+            assertTrue(simpleProjectDto.getMember().getNickname().contains("cc"));
+        }
+    }
+
+    @Test
+    @DisplayName("제목으로 검색")
+    void title_search() {
+        //given
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .title("dd")
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertTrue(result.size() > 0);
+        for (SimpleProjectDto simpleProjectDto : result) {
+            assertTrue(simpleProjectDto.getTitle().contains("dd"));
+        }
+    }
+
+    @Test
+    @DisplayName("내용으로 검색")
+    void content_search() {
+        //given
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .content("cccc")
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertEquals(1, result.size());
+    }
+
+
+    @Test
+    @DisplayName("프로젝트 상태로 필터링")
+    void search_projectStatus() {
+        //given
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .projectStatus(ProjectStatus.RECRUITING)
+                .build();
+        //when
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertTrue(result.size() > 0);
+        for (SimpleProjectDto simpleProjectDto : result) {
+            assertEquals(ProjectStatus.RECRUITING, simpleProjectDto.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("기술스택으로 조회")
+    void search_skillStack() {
+        //given
+        TechStack react = techStackRepository.findById(1L).get();
+        TechStack spring = techStackRepository.findById(3L).get();
+
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .skillsId(List.of(react.getId(), spring.getId()))
+                .build();
+        //when
+
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertEquals(3, result.size());
+
+        for (SimpleProjectDto simpleProjectDto : result) {
+            assertTrue(simpleProjectDto.getTechStacks().stream()
+                    .anyMatch(techStack ->
+                            techStack.getId().equals(react.getId()) ||
+                                    techStack.getId().equals(spring.getId())));
+        }
+    }
+
+    @Test
+    @DisplayName("모든 조건 동시에 적용 조회 테스트")
+    void all_condition_search() {
+        //given
+        TechStack react = techStackRepository.findById(1L).get();
+        TechStack php = techStackRepository.findById(5L).get();
+
+        ProjectCondition projectCondition = ProjectCondition.builder()
+                .limit(TOTAL_DATA_SIZE)
+                .skillsId(List.of(react.getId(), php.getId()))
+                .projectStatus(ProjectStatus.COMPLETED)
+                .title("cccc")
+                .build();
+        //when
+
+        List<SimpleProjectDto> result = queryDslProjectRepository.findAllOptionAndSearch(projectCondition);
+        //then
+
+        assertEquals(3, result.get(0).getId());
+    }
+
+}

--- a/src/test/java/chocoteamteam/togather/repository/impl/QueryDslTestConfig.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QueryDslTestConfig.java
@@ -1,0 +1,22 @@
+package chocoteamteam.togather.repository.impl;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@EnableJpaAuditing
+@TestConfiguration
+public class QueryDslTestConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
**개요**

- #16 
- 프로젝트 목록 조회 기능

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 프로젝트에 queryDsl을 적용하고 검색 및 필터링 조합 로직을 작성하였습니다.

**Test**🧪
- 검색 조건 및 필터링과 페이징 기능이 제대로 동작하는지 테스트하였습니다.
- 조회 특성상 data가 충분히 필요할 것 같아서 insert문을 많이 사용하였습니다.

**Others - optional**
- queryDsl을 아무래도 처음 사용한거라 완전히 만족스럽게 나오진 않은 것 같습니다. 많은 조언 부탁드립니다.
- 테스트 시 전부 조회 로직이라 각 테스트마다 영향이 없을 것 같다고 판단하여 
테스트 시작 전 한번만 대량의 데이터 추가를 위해 PostConstructor를 사용했는데 테스트 메소드마다 동작해서 조건문을 넣고 임의로 구현했는데... 더 좋은 방법이 있다면 알려주시면 감사하겠습니다. -> *지민님 조언으로 해결

### 실행 시 주의사항
- 혹시나 querydsl에서 사용하는 QClass들이 생성이 안돼서 없다고 뜬다면 Gradle -> Tasks -> other -> compileQuerydsl을 실행시키면 Q클래스가 생성됩니다.