### PR TITLE
feat: 로그인, 회원가입 응답객체에 유저 정보와 기술스택 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,9 @@ import lombok.Setter;
 @Builder
 public class LoginResponse {
 
+    private Long id;
+    private String profileImage;
+    private List<TechStackDto> techStackDtos;
     private String signUpToken;
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/chocoteamteam/togather/dto/SignUpControllerDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/SignUpControllerDto.java
@@ -28,6 +28,9 @@ public class SignUpControllerDto {
     @Builder
     public static class Response {
 
+        private Long id;
+        private String profileImage;
+        private List<TechStackDto> techStackDtos;
         private String accessToken;
         private String refreshToken;
 

--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -3,6 +3,8 @@ package chocoteamteam.togather.entity;
 import chocoteamteam.togather.type.MemberStatus;
 import chocoteamteam.togather.type.ProviderType;
 import chocoteamteam.togather.type.Role;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -10,6 +12,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,5 +48,8 @@ public class Member extends BaseTimeEntity{
 
     @Enumerated(EnumType.STRING)
     private ProviderType providerType;
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
 }

--- a/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
@@ -5,7 +5,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,18 +16,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class MemberTechStack extends BaseTimeEntity{
+public class MemberTechStack extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn
     private TechStack techStack;
 
 }

--- a/src/main/java/chocoteamteam/togather/entity/TechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/TechStack.java
@@ -1,14 +1,17 @@
 package chocoteamteam.togather.entity;
 
 import chocoteamteam.togather.type.TechCategory;
-import java.util.ArrayList;
-import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Getter
 @Builder
@@ -16,6 +19,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Entity
 public class TechStack extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,7 +28,5 @@ public class TechStack extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TechCategory category;
     private String image;
-    @OneToMany(mappedBy = "techStack")
-    private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
 }

--- a/src/main/java/chocoteamteam/togather/entity/TechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/TechStack.java
@@ -1,6 +1,8 @@
 package chocoteamteam.togather.entity;
 
 import chocoteamteam.togather.type.TechCategory;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,4 +24,7 @@ public class TechStack extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TechCategory category;
     private String image;
+    @OneToMany(mappedBy = "techStack")
+    private List<MemberTechStack> memberTechStacks = new ArrayList<>();
+
 }


### PR DESCRIPTION
**개요**

- #1 
- OAuth 로그인, 회원가입 응답객체에 유저 정보와 기술스택 추가

**타입** 
- [X]  feat : 새로운 기능 추가

**작업 사항**
- login과 signup Response에  유저 id, profileImage와 기술 스택정보를 들고 있는 techStackDto가 리스트로 추가
- MemberTechStack에 JoinColumn어노테이션 제거 


**Test**🧪

- 기존 테스트에 techStack 추가 검증
- 로그인시 응답값에 회원 id, profileImage, techStack을 잘 가지고 응답하는지 확인하고자 했습니다.

**Others**
memberTechStack이 가지고 있는 TechStack id를 리스트로 만들어 findAllById로 TechStack을 가져왔는데 이 방법이 엔티티 그래프 탐색해 memberTechStack이 들고 있는 techStack을 하나하나 가져오는 것 보다 더 낫다고 생각했습니다, 더 좋은 방법이 있다면 적극 반영하겠습니다!