### PR TITLE
feat: 회원 탈퇴 API 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -50,7 +49,8 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mockito:mockito-inline:2.13.0'
+    testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationToken.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtAuthenticationToken.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.component.security;
 
+import chocoteamteam.togather.dto.LoginMember;
 import java.util.Collection;
 import lombok.Getter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -8,10 +9,10 @@ import org.springframework.security.core.GrantedAuthority;
 @Getter
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
-	private Object principal;
+	private LoginMember principal;
 	private Object credentials;
 
-	public JwtAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+	public JwtAuthenticationToken(LoginMember principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
 		super(authorities);
 		this.principal = principal;
 		this.credentials = credentials;
@@ -24,7 +25,8 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 	}
 
 	@Override
-	public Object getPrincipal() {
+	public LoginMember getPrincipal() {
 		return this.principal;
 	}
+
 }

--- a/src/main/java/chocoteamteam/togather/controller/MemberController.java
+++ b/src/main/java/chocoteamteam/togather/controller/MemberController.java
@@ -2,16 +2,21 @@ package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.MemberDetailResponse;
 import chocoteamteam.togather.service.MemberService;
+import chocoteamteam.togather.type.MemberStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Member", description = "회원 관련 API")
 @RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
@@ -28,4 +33,19 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getDetail(memberId));
     }
 
+	@Operation(
+		summary = "회원 탈퇴", description = "유저 본인 혹은 어드민이 회원탈퇴를 진행할 수 있습니다.",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Member"}
+	)
+	@PreAuthorize("hasRole('USER') and principal.id == #memberId or hasRole('ADMIN')")
+	@PostMapping("/members/{memberId}/withdrawal")
+	public ResponseEntity withdrawal(@PathVariable("memberId") Long memberId) {
+
+		memberService.changeStatus(memberId, MemberStatus.WITHDRAWAL);
+
+		return ResponseEntity.ok().body("");
+	}
+
 }
+

--- a/src/main/java/chocoteamteam/togather/controller/MemberController.java
+++ b/src/main/java/chocoteamteam/togather/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
 		tags = {"Member"}
 	)
 	@PreAuthorize("hasRole('USER') and principal.id == #memberId or hasRole('ADMIN')")
-	@PostMapping("/members/{memberId}/withdrawal")
+	@PostMapping("/{memberId}/withdrawal")
 	public ResponseEntity withdrawal(@PathVariable("memberId") Long memberId) {
 
 		memberService.changeStatus(memberId, MemberStatus.WITHDRAWAL);

--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -52,4 +52,8 @@ public class Member extends BaseTimeEntity{
     @OneToMany(mappedBy = "member")
     private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
+    public void changeStatus(MemberStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/chocoteamteam/togather/service/MemberService.java
+++ b/src/main/java/chocoteamteam/togather/service/MemberService.java
@@ -1,26 +1,30 @@
 package chocoteamteam.togather.service;
 
+import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_MEMBER;
+
 import chocoteamteam.togather.dto.MemberDetailResponse;
-import chocoteamteam.togather.dto.TechStackDto;
 import chocoteamteam.togather.dto.queryDslSimpleDto.MemberTechStackInfoDto;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.MemberException;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.MemberTechStackCustomRepository;
+import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.MemberStatus;
 import java.util.List;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final TechStackRepository techStackRepository;
-
+	private final RefreshTokenRepository refreshTokenRepository;
     private final MemberTechStackCustomRepository memberTechStackCustomRepository;
 
 
@@ -47,4 +51,14 @@ public class MemberService {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
     }
+
+	@Transactional
+	public void changeStatus(@NonNull Long memberId, @NonNull MemberStatus status) {
+		Member member = getMember(memberId);
+
+		member.changeStatus(status);
+
+		refreshTokenRepository.delete(memberId);
+	}
+
 }

--- a/src/test/java/chocoteamteam/togather/service/MemberServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/MemberServiceTest.java
@@ -3,7 +3,9 @@ package chocoteamteam.togather.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
 import chocoteamteam.togather.dto.MemberDetailResponse;
 import chocoteamteam.togather.dto.TechStackDto;
@@ -15,8 +17,7 @@ import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.MemberException;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.MemberTechStackCustomRepository;
-import chocoteamteam.togather.repository.MemberTechStackRepository;
-import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.type.MemberStatus;
 import chocoteamteam.togather.type.ProviderType;
 import chocoteamteam.togather.type.Role;
@@ -37,11 +38,10 @@ class MemberServiceTest {
     @Mock
     MemberRepository memberRepository;
     @Mock
-    MemberTechStackRepository memberTechStackRepository;
-    @Mock
-    TechStackRepository techStackRepository;
-    @Mock
     MemberTechStackCustomRepository memberTechStackCustomRepository;
+
+	@Mock
+	RefreshTokenRepository refreshTokenRepository;
 
     @InjectMocks
     MemberService memberService;
@@ -129,5 +129,48 @@ class MemberServiceTest {
             .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getErrorMessage());
     }
 
+	@DisplayName("회원 상태 변경 성공")
+	@Test
+	void changeStatus_success() {
+		//given
+		given(memberRepository.findById(any()))
+			.willReturn(Optional.of(member));
+
+		doNothing().when(refreshTokenRepository).delete(anyLong());
+
+		//when
+		memberService.changeStatus(1L,MemberStatus.WITHDRAWAL);
+
+		//then
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.WITHDRAWAL);
+	}
+
+	@DisplayName("회원 상태 변경 실패 - 파라미터가 null 인 경우")
+	@Test
+	void changeStatus_fail_parameterIsNull() {
+		//given
+		//when
+		//then
+		assertThatThrownBy(() -> memberService.changeStatus(null,null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> memberService.changeStatus(1L,null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> memberService.changeStatus(null,MemberStatus.WITHDRAWAL))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@DisplayName("회원 상태 변경 실패 - 회원이 조회가 안되는 경우")
+	@Test
+	void changeStatus_fail_memberNotFound() {
+		//given
+		given(memberRepository.findById(any()))
+			.willReturn(Optional.empty());
+
+		//when
+		//then
+		assertThatThrownBy(() -> memberService.changeStatus(1L,MemberStatus.WITHDRAWAL))
+			.isInstanceOf(MemberException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_MEMBER.getErrorMessage());
+	}
 
 }


### PR DESCRIPTION
**개요**

- #22 
- 회원 탈퇴 API 작성

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- Service : 회원 상태 변경 기능 추가 - 상태 변경 시, RefreshToken 같이 삭제
- Controller : 회원 탈퇴 API 추가

**Test**🧪
- 회원 상태 변경 Service 테스트 진행
- 회원 탈퇴 API는 Postman으로 실제 테스트 진행 -> 테스트 코드에서 오류가 발생했는데 해결이 안되어서 직접 테스트 진행했습니다.

**Others**
- 혹시 Controller에서 권한 테스트 작성 시 잘 작동되시는 분은 말씀해주세요 ㅠㅠ
