### PR TITLE
feat: 프로젝트 모집 글 삭제 기능 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -45,4 +45,12 @@ public class ProjectController {
     public ResponseEntity<ProjectDetails> getProjectDetail(@PathVariable Long projectId) {
         return ResponseEntity.ok(projectService.getProject(projectId));
     }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<ProjectDto> deleteProject(
+            @PathVariable Long projectId
+    ) {
+        Long memberId = 1L;
+        return ResponseEntity.ok(projectService.deleteProject(projectId,memberId));
+    }
 }

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -38,7 +38,7 @@ public class Project extends BaseTimeEntity {
 
     private LocalDate deadline;
 
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE)
     private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
 
     public void update(UpdateProjectForm form) {

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -38,7 +38,7 @@ public class Project extends BaseTimeEntity {
 
     private LocalDate deadline;
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "project", cascade =  CascadeType.PERSIST, orphanRemoval = true)
     private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
 
     public void update(UpdateProjectForm form) {

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -117,4 +117,17 @@ public class ProjectService {
         return ProjectDetails.fromEntity(projectRepository.findByIdQuery(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT)));
     }
+
+    @Transactional
+    public ProjectDto deleteProject(Long projectId, Long memberId) {
+        Project project = projectRepository.findByIdQuery(projectId)
+                .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
+
+        if (!Objects.equals(project.getMember().getId(), memberId)) {
+            throw new ProjectException(NOT_MATCH_MEMBER_PROJECT);
+        }
+
+        projectRepository.deleteById(projectId);
+        return ProjectDto.from(project);
+    }
 }

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -327,4 +327,31 @@ class ProjectServiceTest {
 
         assertEquals(999L, projectDetails.getId());
     }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 해당 프로젝트 없음")
+    void deleteProject_NotFoundProject() {
+        //given
+        given(projectRepository.findByIdQuery(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> projectService.deleteProject(1L, 9L));
+
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_PROJECT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 해당 프로젝트 삭제 권한 없음")
+    void name() {
+        //given
+        given(projectRepository.findByIdQuery(anyLong()))
+                .willReturn(Optional.of(project));
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> projectService.deleteProject(1L, 1234L));
+        //then
+        assertEquals(ErrorCode.NOT_MATCH_MEMBER_PROJECT, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
**개요**

- #5 
- 프로젝트 모집 글 삭제 기능 구현

**타입** 

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 프로젝트 모집 글 삭제 기능을 구현했습니다
- 프로젝트가 있는지 확인하고, 프로젝트 작성자와 넘겨 받은 멤버 아이디를 비교해 일치하면 삭제를 하도록 했습니다
- project 삭제 시, projectTechStack에 있던 기록도 같이 지워집니다

**Test**🧪

- 실패하는 경우(프로젝트 존재 X, 멤버 아이디 불일치)에 대해서만 간단히 테스트 했습니다
