### PR TITLE
feat: 회원 정보 수정 API

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/MemberController.java
+++ b/src/main/java/chocoteamteam/togather/controller/MemberController.java
@@ -1,18 +1,24 @@
 package chocoteamteam.togather.controller;
 
+import chocoteamteam.togather.dto.LoginMember;
 import chocoteamteam.togather.dto.MemberDetailResponse;
+import chocoteamteam.togather.dto.SignUpControllerDto;
 import chocoteamteam.togather.service.MemberService;
 import chocoteamteam.togather.type.MemberStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,6 +50,17 @@ public class MemberController {
 
 		memberService.changeStatus(memberId, MemberStatus.WITHDRAWAL);
 
+		return ResponseEntity.ok().body("");
+	}
+
+	@Operation(
+		summary = "회원 정보 수정 Api", description = "로그인한 회원과 요청한 회원을 비교하고 중복되는 닉네임이 없다면 해당 회원의 정보를 수정합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Member"}
+	)
+	@PutMapping("/{memberId}")
+	public ResponseEntity<?> modify(@PathVariable @Positive Long memberId, @RequestBody @Valid
+	SignUpControllerDto.Request request, @AuthenticationPrincipal LoginMember loginMember) {
+		memberService.modify(memberId, request, loginMember.getId());
 		return ResponseEntity.ok().body("");
 	}
 

--- a/src/main/java/chocoteamteam/togather/entity/Member.java
+++ b/src/main/java/chocoteamteam/togather/entity/Member.java
@@ -56,4 +56,9 @@ public class Member extends BaseTimeEntity{
         this.status = status;
     }
 
+    public void modifyNicknameAndProfileImage(String nickname, String profileImage) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
 }

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     MEMBER_STATUS_WITHDRAWAL(HttpStatus.UNAUTHORIZED, "탈퇴한 회원입니다."),
     ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "비정상적인 접근입니다."),
 
-
+    MISS_MATCH_MEMBER(HttpStatus.BAD_REQUEST, "본인 정보만 수정할 수 있습니다."),
     EXIST_TRUE_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     MISS_MATCH_PROVIDER(HttpStatus.BAD_REQUEST, "다른 SNS 계정으로 회원가입이 돼있습니다."),
     NOT_FOUND_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),

--- a/src/main/java/chocoteamteam/togather/repository/MemberRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/MemberRepository.java
@@ -2,11 +2,18 @@ package chocoteamteam.togather.repository;
 
 import chocoteamteam.togather.entity.Member;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
+    @EntityGraph(attributePaths = {"memberTechStacks"}, type = EntityGraphType.LOAD)
+    Optional<Member> findWithMemberTechStackById(Long id);
 
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/chocoteamteam/togather/repository/MemberTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/MemberTechStackRepository.java
@@ -1,8 +1,17 @@
 package chocoteamteam.togather.repository;
 
 import chocoteamteam.togather.entity.MemberTechStack;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MemberTechStackRepository extends JpaRepository<MemberTechStack, Long> {
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MemberTechStack mts where mts.id in :ids")
+    void deleteAllByIdInQuery(@Param("ids") Iterable<Long> ids);
 
 }

--- a/src/main/java/chocoteamteam/togather/service/MemberService.java
+++ b/src/main/java/chocoteamteam/togather/service/MemberService.java
@@ -1,18 +1,24 @@
 package chocoteamteam.togather.service;
 
-import static chocoteamteam.togather.exception.ErrorCode.NOT_FOUND_MEMBER;
-
 import chocoteamteam.togather.dto.MemberDetailResponse;
+import chocoteamteam.togather.dto.SignUpControllerDto.Request;
 import chocoteamteam.togather.dto.queryDslSimpleDto.MemberTechStackInfoDto;
 import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.MemberTechStack;
+import chocoteamteam.togather.entity.TechStack;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.MemberException;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.MemberTechStackCustomRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
 import chocoteamteam.togather.repository.RefreshTokenRepository;
 import chocoteamteam.togather.repository.TechStackRepository;
 import chocoteamteam.togather.type.MemberStatus;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-	private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TechStackRepository techStackRepository;
+    private final MemberTechStackRepository memberTechStackRepository;
     private final MemberTechStackCustomRepository memberTechStackCustomRepository;
 
 
@@ -52,13 +60,66 @@ public class MemberService {
             .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
-	@Transactional
-	public void changeStatus(@NonNull Long memberId, @NonNull MemberStatus status) {
-		Member member = getMember(memberId);
+    @Transactional
+    public void changeStatus(@NonNull Long memberId, @NonNull MemberStatus status) {
+        Member member = getMember(memberId);
 
-		member.changeStatus(status);
+        member.changeStatus(status);
 
-		refreshTokenRepository.delete(memberId);
-	}
+        refreshTokenRepository.delete(memberId);
+    }
+
+    @Transactional
+    public void modify(Long memberId, Request request, Long loginId) {
+
+        //  로그인한 회원 Id와 요청을 보낸 회원 Id가 다를 경우 예외 발생
+        if (!Objects.equals(loginId, memberId)) {
+            throw new MemberException(ErrorCode.MISS_MATCH_MEMBER);
+        }
+
+        /*  닉네임으로 회원을 가져와 회원이 존재할 경우
+            해당 회원 Id과 현재 수정을 요청한 회원 Id를 비교해 다를 경우 예외 발생
+         */
+        Optional<Member> byNickname = memberRepository.findByNickname(request.getNickname());
+        if (byNickname.isPresent() && !Objects.equals(byNickname.get().getId(), memberId)) {
+            throw new MemberException(ErrorCode.EXIST_TRUE_MEMBER_NICKNAME);
+        }
+
+        //  회원과 회원이 가지고 있는 기술 스택 한 번에 가져옴 회원이 존재하지 않을 경우 예외 발생
+        Member member = memberRepository.findWithMemberTechStackById(memberId)
+            .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+        member.modifyNicknameAndProfileImage(request.getNickname(), request.getProfileImage());
+
+        // 삭제할 MemberTechStackId와 저장할 TechStackId를 구분
+        List<MemberTechStack> memberTechStacks = member.getMemberTechStacks();
+        Set<Long> requestTechStackIds = new HashSet<>(request.getTechStackDtos());
+        Set<Long> deleteMemberTechStackIds = new HashSet<>();
+
+        for (MemberTechStack memberTechStack : memberTechStacks) {
+            Long curMemberTechStackId = memberTechStack.getTechStack().getId();
+            if (requestTechStackIds.contains(curMemberTechStackId)) {
+                requestTechStackIds.remove(curMemberTechStackId);
+                continue;
+            }
+            deleteMemberTechStackIds.add(curMemberTechStackId);
+        }
+
+        // 삭제할 MemberTechStackId List가 비어있지 않다면 삭제
+        if (!deleteMemberTechStackIds.isEmpty()) {
+            memberTechStackRepository.deleteAllByIdInQuery(deleteMemberTechStackIds);
+        }
+
+        // 저장할 TechStackId List가 비어있지 않다면 저장
+        if (!requestTechStackIds.isEmpty()) {
+            List<TechStack> techStacks = techStackRepository.findAllById(requestTechStackIds);
+            for (TechStack techStack : techStacks) {
+                memberTechStackRepository.save(MemberTechStack.builder()
+                    .member(member)
+                    .techStack(techStack)
+                    .build());
+            }
+        }
+
+    }
 
 }

--- a/src/main/java/chocoteamteam/togather/service/MemberService.java
+++ b/src/main/java/chocoteamteam/togather/service/MemberService.java
@@ -80,38 +80,56 @@ public class MemberService {
         /*  닉네임으로 회원을 가져와 회원이 존재할 경우
             해당 회원 Id과 현재 수정을 요청한 회원 Id를 비교해 다를 경우 예외 발생
          */
-        Optional<Member> byNickname = memberRepository.findByNickname(request.getNickname());
-        if (byNickname.isPresent() && !Objects.equals(byNickname.get().getId(), memberId)) {
-            throw new MemberException(ErrorCode.EXIST_TRUE_MEMBER_NICKNAME);
-        }
+        checkMemberIdAndNickname(request.getNickname(), memberId);
 
         //  회원과 회원이 가지고 있는 기술 스택 한 번에 가져옴 회원이 존재하지 않을 경우 예외 발생
         Member member = memberRepository.findWithMemberTechStackById(memberId)
             .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+
+        // 회원 정보 수정
         member.modifyNicknameAndProfileImage(request.getNickname(), request.getProfileImage());
 
         // 삭제할 MemberTechStackId와 저장할 TechStackId를 구분
         List<MemberTechStack> memberTechStacks = member.getMemberTechStacks();
         Set<Long> requestTechStackIds = new HashSet<>(request.getTechStackDtos());
         Set<Long> deleteMemberTechStackIds = new HashSet<>();
-
-        for (MemberTechStack memberTechStack : memberTechStacks) {
-            Long curMemberTechStackId = memberTechStack.getTechStack().getId();
-            if (requestTechStackIds.contains(curMemberTechStackId)) {
-                requestTechStackIds.remove(curMemberTechStackId);
-                continue;
-            }
-            deleteMemberTechStackIds.add(curMemberTechStackId);
-        }
+        initMemberTechStackDeleteAndInsertIds(
+            memberTechStacks,
+            requestTechStackIds,
+            deleteMemberTechStackIds
+        );
 
         // 삭제할 MemberTechStackId List가 비어있지 않다면 삭제
-        if (!deleteMemberTechStackIds.isEmpty()) {
-            memberTechStackRepository.deleteAllByIdInQuery(deleteMemberTechStackIds);
-        }
+        deleteByMemberTechStackIds(deleteMemberTechStackIds);
 
         // 저장할 TechStackId List가 비어있지 않다면 저장
-        if (!requestTechStackIds.isEmpty()) {
-            List<TechStack> techStacks = techStackRepository.findAllById(requestTechStackIds);
+        saveByMemberTechStack(member, requestTechStackIds);
+    }
+
+    private void initMemberTechStackDeleteAndInsertIds(List<MemberTechStack> memberTechStacks,
+        Set<Long> insertIds,
+        Set<Long> deleteIds) {
+        for (MemberTechStack memberTechStack : memberTechStacks) {
+            Long curMemberTechStackId = memberTechStack.getTechStack().getId();
+            if (insertIds.contains(curMemberTechStackId)) {
+                insertIds.remove(curMemberTechStackId);
+                continue;
+            }
+            deleteIds.add(curMemberTechStackId);
+        }
+    }
+
+    private void checkMemberIdAndNickname(String nickname, Long memberId) {
+        Optional<Member> byNickname = memberRepository.findByNickname(nickname);
+        if (byNickname.isPresent() && !Objects.equals(byNickname.get().getId(), memberId)) {
+            throw new MemberException(ErrorCode.EXIST_TRUE_MEMBER_NICKNAME);
+        }
+
+    }
+
+    private void saveByMemberTechStack(Member member, Set<Long> techStackIds) {
+        if (!techStackIds.isEmpty()) {
+            List<TechStack> techStacks = techStackRepository.findAllById(techStackIds);
             for (TechStack techStack : techStacks) {
                 memberTechStackRepository.save(MemberTechStack.builder()
                     .member(member)
@@ -119,7 +137,12 @@ public class MemberService {
                     .build());
             }
         }
+    }
 
+    private void deleteByMemberTechStackIds(Set<Long> ids) {
+        if (!ids.isEmpty()) {
+            memberTechStackRepository.deleteAllByIdInQuery(ids);
+        }
     }
 
 }


### PR DESCRIPTION
**개요**

- Closes #22 
- 회원 본인의 정보를 수정할 수 있는 API

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- 로그인한 회원 id와 request로 받는 id를 비교해 로그인한 회원 본인이 맞다면 정보를 수정하도록 처리 했습니다.
- MemberTechStack 테이블에 사용 상태 컬럼을 추가해 soft delete 하는 방법도 고민해봤지만, 유용한 데이터도 아니라고 생각하고, 남아있는 데이터를 활용하지도 않는다고 생각해 id 리스트를 받아 한번 쿼리에 삭제하도록 @Query를 사용해 hard delete를 선택했습니다.

**Test**🧪

- 성공 - 정상적으로 값이 주어졌을 때 정보 수정이 되는지 확인 (Member가 들고있는 MemberTechStack부분은 postman을 사용해 확인했습니다.)
- 실패 
    - 회원 본인이 아닐 경우
    - 회원이 존재하지 않을 경우
    - 수정하고자 하는 닉네임이 본인이 아닌 다른 회원의 닉네임으로 사용하고 있을 경우

**Others - optional**

![test1](https://user-images.githubusercontent.com/71117490/191233158-7456cf12-63ee-4119-aafa-f62d7dad416a.PNG)
![test2](https://user-images.githubusercontent.com/71117490/191233167-1857555d-0aaa-4f34-9c21-238b29e73d12.PNG)
![test3](https://user-images.githubusercontent.com/71117490/191233173-61b0df8a-220d-4116-98d3-aa9f973c17ae.PNG)