### PR TITLE
fix: project 등록,수정,삭제할 때 로그인 정보 가져오는 부분 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -75,7 +75,7 @@ public class ProjectController {
 
     @Operation(
             summary = "프로젝트 모집글 삭제",
-            description = "프로젝트 모집글을 삭제합니다. 본인이 쓴 글만 삭제 가능합니다",
+            description = "프로젝트 모집글을 삭제합니다. 일반 회원은 본인이 쓴 글만 삭제가능하며 ADMIN은 전부 삭제 가능합니다",
             security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
     )
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
@@ -84,6 +84,6 @@ public class ProjectController {
             @AuthenticationPrincipal LoginMember member,
             @PathVariable Long projectId
     ) {
-        return ResponseEntity.ok(projectService.deleteProject(projectId, member.getId()));
+        return ResponseEntity.ok(projectService.deleteProject(projectId, member));
     }
 }

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -2,55 +2,88 @@ package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.*;
 import chocoteamteam.togather.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
+@Tag(name = "Project", description = "프로젝트 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/projects")
 public class ProjectController {
     private final ProjectService projectService;
 
-    // 나중에 memberId 받아오기
+    @Operation(
+            summary = "프로젝트 모집글 등록",
+            description = "프로젝트 모집글을 등록합니다. 로그인 하지 않은 유저는 불가능합니다",
+            security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
+    )
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<ProjectDto> createProject(
+            @AuthenticationPrincipal LoginMember member,
             @Valid @RequestBody CreateProjectForm form
     ) {
-        Long memberId = 1L;
         return ResponseEntity.ok(
-                projectService.createProject(memberId, form)
+                projectService.createProject(member.getId(), form)
         );
     }
 
+    @Operation(
+            summary = "프로젝트 모집글 수정",
+            description = "프로젝트 모집글을 수정합니다. 본인이 쓴 글만 수정 가능합니다",
+            security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
+    )
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PutMapping("/{projectId}")
     public ResponseEntity<ProjectDto> updateProject(
+            @AuthenticationPrincipal LoginMember member,
             @PathVariable Long projectId,
             @Valid @RequestBody UpdateProjectForm form
     ) {
-        Long memberId = 1L;
         return ResponseEntity.ok(
-                projectService.updateProject(projectId, memberId, form)
+                projectService.updateProject(projectId, member.getId(), form)
         );
     }
 
+    @Operation(
+            summary = "프로젝트 모집글 목록 조회",
+            description = "프로젝트 모집글 목록을 조회합니다",
+            tags = {"Project"}
+    )
     @GetMapping
     public ResponseEntity<?> getProjectList(@Valid ProjectCondition projectCondition) {
         return ResponseEntity.ok(projectService.getProjectList(projectCondition));
     }
 
+    @Operation(
+            summary = "프로젝트 모집글 상세 조회",
+            description = "특정 프로젝트 모집글을 상세 조회합니다",
+            tags = {"Project"}
+    )
     @GetMapping("/{projectId}")
     public ResponseEntity<ProjectDetails> getProjectDetail(@PathVariable Long projectId) {
         return ResponseEntity.ok(projectService.getProject(projectId));
     }
 
+    @Operation(
+            summary = "프로젝트 모집글 삭제",
+            description = "프로젝트 모집글을 삭제합니다. 본인이 쓴 글만 삭제 가능합니다",
+            security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
+    )
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @DeleteMapping("/{projectId}")
     public ResponseEntity<ProjectDto> deleteProject(
+            @AuthenticationPrincipal LoginMember member,
             @PathVariable Long projectId
     ) {
-        Long memberId = 1L;
-        return ResponseEntity.ok(projectService.deleteProject(projectId,memberId));
+        return ResponseEntity.ok(projectService.deleteProject(projectId, member.getId()));
     }
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -12,6 +12,7 @@ import chocoteamteam.togather.repository.ProjectRepository;
 import chocoteamteam.togather.repository.ProjectTechStackRepository;
 import chocoteamteam.togather.repository.TechStackRepository;
 import chocoteamteam.togather.type.ProjectStatus;
+import chocoteamteam.togather.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -119,15 +120,16 @@ public class ProjectService {
     }
 
     @Transactional
-    public ProjectDto deleteProject(Long projectId, Long memberId) {
+    public ProjectDto deleteProject(Long projectId, LoginMember member) {
         Project project = projectRepository.findByIdQuery(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
 
-        if (!Objects.equals(project.getMember().getId(), memberId)) {
+        if (!Objects.equals(project.getMember().getId(), member.getId()) &&
+                member.getRole() != Role.ROLE_ADMIN) {
             throw new ProjectException(NOT_MATCH_MEMBER_PROJECT);
         }
 
-        projectRepository.deleteById(projectId);
+        projectRepository.deleteById(project.getId());
         return ProjectDto.from(project);
     }
 }


### PR DESCRIPTION
**개요**

- #5
- project 컨트롤러에 로그인 정보 받아오는 부분 추가

**타입** 

- [x]  fix : 버그 수정이나 로직 변경 등의 수정

**작업 사항**
- @AuthenticationPrincipal을 이용해 로그인 정보를 받아옵니다
- 쉽게 테스트할 수 있도록 각각 swagger 설정을 추가했습니다

