### PR TITLE
feat: 회원 로그인 성공시 Response에 회원 닉네임 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/LoginResponse.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 public class LoginResponse {
 
     private Long id;
+    private String nickname;
     private String profileImage;
     private List<TechStackDto> techStackDtos;
     private String signUpToken;

--- a/src/main/java/chocoteamteam/togather/service/OAuthService.java
+++ b/src/main/java/chocoteamteam/togather/service/OAuthService.java
@@ -88,7 +88,7 @@ public class OAuthService {
             throw new CustomOAuthException(ErrorCode.MISS_MATCH_PROVIDER);
         }
 
-        if (!member.getStatus().toString().equals(MemberStatus.PERMITTED.toString())) {
+        if (member.getStatus() != MemberStatus.PERMITTED) {
             throw new CustomOAuthException(ErrorCode.MEMBER_STATUS_WITHDRAWAL);
         }
 

--- a/src/main/java/chocoteamteam/togather/service/OAuthService.java
+++ b/src/main/java/chocoteamteam/togather/service/OAuthService.java
@@ -92,6 +92,7 @@ public class OAuthService {
 
         return LoginResponse.builder()
             .id(member.getId())
+            .nickname(member.getNickname())
             .profileImage(member.getProfileImage())
             .techStackDtos(getTechStackDtosFromMember(member))
             .accessToken(tokens.getAccessToken())

--- a/src/main/java/chocoteamteam/togather/service/OAuthService.java
+++ b/src/main/java/chocoteamteam/togather/service/OAuthService.java
@@ -88,6 +88,10 @@ public class OAuthService {
             throw new CustomOAuthException(ErrorCode.MISS_MATCH_PROVIDER);
         }
 
+        if (!member.getStatus().toString().equals(MemberStatus.PERMITTED.toString())) {
+            throw new CustomOAuthException(ErrorCode.MEMBER_STATUS_WITHDRAWAL);
+        }
+
         Tokens tokens = getTokens(member);
 
         return LoginResponse.builder()


### PR DESCRIPTION
**개요**
- 회원 로그인 성공시 회원의 닉네임 응답에 추가, 로그인 시 상태 검증 추가


**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 회원 로그인 성공시 기존 응답하면 LoginResponse에 nickname 필드를 추가해서 응답하도록 했습니다.
- 회원 로그인시 회원의 상태가 PERMITTED이 아니면 예외를 발생시키도록 했습니다.


**Others - optional**
- loginResponse부분은 재원님의 요청으로 간단하게 응답객체에 필드만 추가했습니다.
