### PR TITLE
feat: 프로젝트 댓글 api

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/CommentController.java
+++ b/src/main/java/chocoteamteam/togather/controller/CommentController.java
@@ -1,0 +1,47 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.CommentDto;
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @Operation(
+            summary = "댓글 생성 api", description = "댓글을 생성하고 생성된 댓글을 반환합니다.",
+            security = {@SecurityRequirement(name = "Authorization")})
+    @PostMapping("/projects/{projectId}/comments")
+    public ResponseEntity<CommentDto> createComment(@PathVariable Long projectId,
+                                                    @AuthenticationPrincipal LoginMember loginMember, @RequestBody String content) {
+        return ResponseEntity.ok(commentService.createComment(projectId, content, loginMember.getId()));
+    }
+
+    @Operation(
+            summary = "댓글 수정 api", description = "댓글을 수정하고 수정된 댓글을 반환합니다.",
+            security = {@SecurityRequirement(name = "Authorization")})
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<CommentDto> modifyComment(@PathVariable Long commentId,
+                                                    @AuthenticationPrincipal LoginMember loginMember, @RequestBody String content) {
+        return ResponseEntity.ok(commentService.modifyComment(commentId, content, loginMember.getId()));
+    }
+
+    @Operation(
+            summary = "댓글 삭제 api", description = "댓글을 삭제합니다.",
+            security = {@SecurityRequirement(name = "Authorization")})
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId,
+                                           @AuthenticationPrincipal LoginMember loginMember) {
+        commentService.deleteComment(commentId, loginMember.getId(), loginMember.getRole());
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/CommentDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/CommentDto.java
@@ -1,0 +1,33 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.entity.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDto {
+    private Long id;
+
+    private MemberDto member;
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    public static CommentDto fromEntity(Comment comment) {
+        return CommentDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .member(MemberDto.from(comment.getMember()))
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/chocoteamteam/togather/dto/ProjectDetails.java
+++ b/src/main/java/chocoteamteam/togather/dto/ProjectDetails.java
@@ -26,6 +26,7 @@ public class ProjectDetails {
     private LocalDate deadline;
     private boolean offline;
     private List<TechStackDto> techStacks;
+    private List<CommentDto> comments;
 
     public static ProjectDetails fromEntity(Project project) {
         return ProjectDetails.builder()
@@ -41,6 +42,9 @@ public class ProjectDetails {
                 .techStacks(project.getProjectTechStacks()
                         .stream()
                         .map(projectTechStack -> TechStackDto.from(projectTechStack.getTechStack()))
+                        .collect(Collectors.toList()))
+                .comments(project.getComments().stream()
+                        .map(CommentDto::fromEntity)
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/chocoteamteam/togather/entity/Comment.java
+++ b/src/main/java/chocoteamteam/togather/entity/Comment.java
@@ -1,0 +1,27 @@
+package chocoteamteam.togather.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+}

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -41,6 +41,14 @@ public class Project extends BaseTimeEntity {
     @OneToMany(mappedBy = "project", cascade =  CascadeType.PERSIST, orphanRemoval = true)
     private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private final List<Comment> comments = new ArrayList<>();
+
+    public void addComment(Comment comment) {
+        this.comments.add(comment);
+        comment.setProject(this);
+    }
+
     public void update(UpdateProjectForm form) {
         this.title = form.getTitle();
         this.content = form.getContent();

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -23,7 +23,11 @@ public enum ErrorCode {
     NOT_FOUND_PROJECT(HttpStatus.BAD_REQUEST, "프로젝트를 찾을 수 없습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않은 인증 토큰 입니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러 입니다."),
-    NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다.");
+    NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다."),
+
+
+    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/repository/CommentRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"member"})
+    Optional<Comment> findById(Long commentId);
+
+    Optional<Comment> findByIdAndMemberId(Long id, Long member_id);
+}

--- a/src/main/java/chocoteamteam/togather/service/CommentService.java
+++ b/src/main/java/chocoteamteam/togather/service/CommentService.java
@@ -1,0 +1,77 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.CommentDto;
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.entity.Comment;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.MemberException;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.CommentRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static chocoteamteam.togather.exception.ErrorCode.*;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final ProjectRepository projectRepository;
+
+    @Transactional
+    public CommentDto createComment(Long projectId, String content, Long memberId) {
+        Member member = getMember(memberId);
+        Project project = getProject(projectId);
+        Comment comment = commentRepository.save(Comment.builder()
+                .member(member)
+                .content(content)
+                .build());
+
+        project.addComment(comment);
+        return CommentDto.fromEntity(comment);
+    }
+
+    @Transactional
+    public CommentDto modifyComment(Long commentId, String content, Long memberId) {
+        Comment comment = getCommentByMemberId(memberId, commentId);
+
+        comment.setContent(content);
+        return CommentDto.fromEntity(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId, Role role) {
+        if (role.equals(Role.ROLE_ADMIN)) {
+            commentRepository.delete(getComment(commentId));
+        } else {
+            commentRepository.delete(getCommentByMemberId(commentId, memberId));
+        }
+    }
+
+    private Comment getCommentByMemberId(Long commentId, Long memberId) {
+        return commentRepository.findByIdAndMemberId(commentId, memberId)
+                .orElseThrow(() -> new ProjectException(NO_PERMISSION));
+    }
+
+    private Comment getComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new ProjectException(NOT_FOUND_COMMENT));
+    }
+
+    private Project getProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -114,6 +114,7 @@ public class ProjectService {
         return projectRepository.findAllOptionAndSearch(projectCondition);
     }
 
+    @Transactional
     public ProjectDetails getProject(Long projectId) {
         return ProjectDetails.fromEntity(projectRepository.findByIdQuery(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT)));

--- a/src/test/java/chocoteamteam/togather/service/CommentServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/CommentServiceTest.java
@@ -1,0 +1,127 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.CommentDto;
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.entity.Comment;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.CommentRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글 생성")
+    void create_Comment() {
+        //given
+        Member member = Member.builder()
+                .id(9L)
+                .nickname("두개더")
+                .profileImage("img_url")
+                .build();
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member));
+        given(projectRepository.findById(anyLong()))
+                .willReturn(Optional.of(Project.builder()
+                        .id(99L)
+                        .build()));
+        given(commentRepository.save(any()))
+                .willReturn(Comment.builder()
+                        .id(123L)
+                        .content("댓글 내용")
+                        .member(member)
+                        .build());
+        //when
+        CommentDto commentDto = commentService.createComment(123L, "댓글 내용", 9L);
+        //then
+        assertEquals(123L, commentDto.getId());
+        assertEquals("댓글 내용", commentDto.getContent());
+        assertEquals(member.getId(), commentDto.getMember().getId());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void modify_Comment() {
+        //given
+        Member member = Member.builder()
+                .id(9L)
+                .nickname("두개더")
+                .profileImage("img_url")
+                .build();
+        given(commentRepository.findByIdAndMemberId(anyLong(), anyLong()))
+                .willReturn(Optional.ofNullable(Comment.builder()
+                        .id(123L)
+                        .content("댓글 내용")
+                        .member(member)
+                        .build()));
+        //when
+        CommentDto commentDto = commentService.modifyComment(123L, "수정 내용", 9L);
+
+        //then
+        assertEquals(123L, commentDto.getId());
+        assertEquals("수정 내용", commentDto.getContent());
+        assertEquals(member.getId(), commentDto.getMember().getId());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패")
+    void modify_Comment_fail() {
+        //given
+        given(commentRepository.findByIdAndMemberId(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> commentService.modifyComment(123L, "수정 내용",99L));
+
+        //then
+        assertEquals(ErrorCode.NO_PERMISSION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 실패")
+    void delete_Comment() {
+        //given
+        Member member = Member.builder()
+                .id(9L)
+                .build();
+        given(commentRepository.findByIdAndMemberId(anyLong(),anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        ProjectException exception = assertThrows(ProjectException.class,
+                () -> commentService.deleteComment(123L, 1L, Role.ROLE_USER));
+
+        //then
+        assertEquals(ErrorCode.NO_PERMISSION, exception.getErrorCode());
+    }
+
+}

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -1,10 +1,7 @@
 package chocoteamteam.togather.service;
 
 import chocoteamteam.togather.dto.*;
-import chocoteamteam.togather.entity.Member;
-import chocoteamteam.togather.entity.Project;
-import chocoteamteam.togather.entity.ProjectTechStack;
-import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.entity.*;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.ProjectException;
 import chocoteamteam.togather.repository.MemberRepository;
@@ -293,16 +290,8 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 상세조회 성공")
+    @DisplayName("프로젝트 상세조회 성공 (댓글 추가)")
     void getProject_success() {
-        member = Member.builder()
-                .id(9L)
-                .email("togather@to.com")
-                .nickname("두개더")
-                .profileImage("img_url")
-                .build();
-
-
         project = Project.builder()
                 .id(999L)
                 .member(member)
@@ -314,16 +303,20 @@ class ProjectServiceTest {
                 .offline(true)
                 .deadline(LocalDate.of(2022, 9, 12))
                 .build();
+
+        project.addComment(Comment.builder().member(member).id(1L).build());
+        project.addComment(Comment.builder().member(member).id(2L).build());
+        project.addComment(Comment.builder().member(member).id(3L).build());
         //given
         given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(project));
-
 
         //when
         ProjectDetails projectDetails = projectService.getProject(1L);
         //then
 
         assertEquals(999L, projectDetails.getId());
+        assertEquals(3, projectDetails.getComments().size());
     }
 
     @Test


### PR DESCRIPTION
**개요**

- #36 
- 댓글 api를 구현합니다.

**타입** 

- [x]  feat : 새로운 기능 추가

**작업 사항**
- 댓글 생성 수정 삭제 및 프로젝트 조회 시 같이 조회되게 구현하였습니다.
- 최대한 적은 쿼리를 발생하도록 구조를 가져갔습니다.

**Test**🧪

- 서비스로직에 간단한 테스트를 하였습니다.

**Others - optional**

