### PR TITLE
fix,refactor: 프로젝트 수정 오류 해결, 검증 부분 정리

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -84,6 +84,6 @@ public class ProjectController {
             @AuthenticationPrincipal LoginMember member,
             @PathVariable Long projectId
     ) {
-        return ResponseEntity.ok(projectService.deleteProject(projectId, member));
+        return ResponseEntity.ok(projectService.deleteProject(projectId, member.getId(), member.getRole()));
     }
 }

--- a/src/main/java/chocoteamteam/togather/entity/Project.java
+++ b/src/main/java/chocoteamteam/togather/entity/Project.java
@@ -38,7 +38,7 @@ public class Project extends BaseTimeEntity {
 
     private LocalDate deadline;
 
-    @OneToMany(mappedBy = "project", cascade =  CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "project")
     private final List<ProjectTechStack> projectTechStacks = new ArrayList<>();
 
     public void update(UpdateProjectForm form) {

--- a/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
@@ -6,13 +6,15 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
 
-    @Query(value = "select tech_stack_id from project_tech_stack where project_id=:id", nativeQuery = true)
-    List<Long> findTechStackIdsByProjectId(@Param("id") Long projectId);
-
+    @Transactional
     @Modifying
-    List<ProjectTechStack> deleteAllByIdIn(List<Long> ids);
+    @Query("delete from ProjectTechStack pt where pt.id in :ids")
+    void deleteAllByIdInQuery(@Param("ids") List<Long> ids);
+
+    void deleteByProjectId(Long projectId);
 }

--- a/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectTechStackRepository.java
@@ -6,13 +6,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
 
-    @Transactional
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from ProjectTechStack pt where pt.id in :ids")
     void deleteAllByIdInQuery(@Param("ids") List<Long> ids);
 

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -1,6 +1,9 @@
 package chocoteamteam.togather.service;
 
-import chocoteamteam.togather.dto.*;
+import chocoteamteam.togather.dto.CreateProjectForm;
+import chocoteamteam.togather.dto.ProjectDetails;
+import chocoteamteam.togather.dto.ProjectDto;
+import chocoteamteam.togather.dto.UpdateProjectForm;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
 import chocoteamteam.togather.entity.ProjectTechStack;
@@ -339,10 +342,7 @@ class ProjectServiceTest {
         given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(project));
         //when
-        projectService.deleteProject(1L, LoginMember.builder()
-                .id(project.getMember().getId())
-                .role(Role.ROLE_USER)
-                .build());
+        projectService.deleteProject(1L, member.getId(), Role.ROLE_USER);
         //then
         verify(projectRepository, times(1)).deleteById(project.getId());
     }
@@ -354,10 +354,7 @@ class ProjectServiceTest {
         given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(project));
         //when
-        projectService.deleteProject(3L, LoginMember.builder()
-                .id(1234L)
-                .role(Role.ROLE_ADMIN)
-                .build());
+        projectService.deleteProject(3L, 1234L, Role.ROLE_ADMIN);
         //then
         verify(projectRepository, times(1)).deleteById(project.getId());
     }
@@ -370,7 +367,7 @@ class ProjectServiceTest {
                 .willReturn(Optional.empty());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
-                () -> projectService.deleteProject(1L, LoginMember.builder().build()));
+                () -> projectService.deleteProject(1L, 1234L, Role.ROLE_USER));
 
         //then
         assertEquals(ErrorCode.NOT_FOUND_PROJECT, exception.getErrorCode());
@@ -384,10 +381,7 @@ class ProjectServiceTest {
                 .willReturn(Optional.of(project));
         //when
         ProjectException exception = assertThrows(ProjectException.class,
-                () -> projectService.deleteProject(1L, LoginMember.builder()
-                        .id(9876L)
-                        .role(Role.ROLE_USER)
-                        .build()));
+                () -> projectService.deleteProject(1L, 1234L, Role.ROLE_USER));
         //then
         assertEquals(ErrorCode.NOT_MATCH_MEMBER_PROJECT, exception.getErrorCode());
     }

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -1,13 +1,7 @@
 package chocoteamteam.togather.service;
 
-import chocoteamteam.togather.dto.CreateProjectForm;
-import chocoteamteam.togather.dto.ProjectDetails;
-import chocoteamteam.togather.dto.ProjectDto;
-import chocoteamteam.togather.dto.UpdateProjectForm;
-import chocoteamteam.togather.entity.Member;
-import chocoteamteam.togather.entity.Project;
-import chocoteamteam.togather.entity.ProjectTechStack;
-import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.dto.*;
+import chocoteamteam.togather.entity.*;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.ProjectException;
 import chocoteamteam.togather.repository.MemberRepository;

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -168,7 +168,10 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 수정 성공")
     void updateProjectSuccess() {
         //given
-        Project testProject = Project.builder().id(999L).member(member).build();
+        Project testProject = Project.builder()
+                .id(project.getId())
+                .member(member)
+                .build();
         TechStack techStack1 = TechStack.builder().id(1L).build();
         TechStack techStack2 = TechStack.builder().id(2L).build();
         TechStack techStack3 = TechStack.builder().id(3L).build();
@@ -183,29 +186,32 @@ class ProjectServiceTest {
         ProjectTechStack projectTechStack3 = new ProjectTechStack(testProject, techStack3);
         projectTechStack3.setId(3L);
 
+        /*
+         * 헷갈리지 않기 위해 기술 스택과 모집 기술 스택 아이디를 일치시켰는데
+         * (ex 모집 기술 스택 1번 - 기술 스택 1번)
+         * 실제로는 구분하여 동작합니다
+         * 지울 때는 모집 기술 스택 ID로 지우며,
+         * 새로 추가할 때는 기술 스택 ID로 기술 스택 정보를 불러와서 모집 기술 스택 객체를 만들어 추가합니다
+         * (추가하는 부분은 프로젝트 생성 시 기술 스택 추가 부분과 동일합니다)
+         * 기존 기술 스택 ID : 1,2,3
+         * 새로 받은 기술 스택 ID : 3,4,5,6
+         * 지워야 할 모집 기술 스택 ID : 1,2
+         * 새로 추가 될 기술 스택 ID : 4,5,6
+         * 최종 모집 기술 스택 ID : 3,4,5,6
+         */
 
-        //기존 기술 스택
-        List<Long> prevTech = new ArrayList<>(List.of(1L, 2L, 3L));
-        //새로 입력받은 기술 스택
+        //새로 입력받은 기술 스택 ID
         List<Long> newTech = new ArrayList<>(List.of(3L, 4L, 5L, 6L));
-        //삭제 되어야할 기술 스택들
-        List<ProjectTechStack> deleteList = List.of(projectTechStack1, projectTechStack2);
 
-        given(projectRepository.findById(anyLong()))
+        given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(testProject));
-
-        given(projectTechStackRepository.findTechStackIdsByProjectId(anyLong()))
-                .willReturn(prevTech);
-
-        given(projectTechStackRepository.deleteAllByIdIn(any()))
-                .willReturn(deleteList);
 
         given(techStackRepository.findAllById(any()))
                 .willReturn(List.of(techStack4, techStack5, techStack6));
 
         //when
         ProjectDto projectDto = projectService.updateProject(
-                project.getId(),
+                testProject.getId(),
                 member.getId(),
                 UpdateProjectForm.builder()
                         .title("수정 제목")
@@ -219,7 +225,7 @@ class ProjectServiceTest {
         assertEquals(techStack5.getId(), projectDto.getProjectTechStacks().get(2).getTechStack().getId());
         assertEquals(techStack6.getId(), projectDto.getProjectTechStacks().get(3).getTechStack().getId());
         assertEquals("수정 제목", projectDto.getTitle());
-        verify(projectTechStackRepository, times(1)).deleteAllByIdIn(List.of(1L, 2L));
+        verify(projectTechStackRepository, times(1)).deleteAllByIdInQuery(List.of(1L, 2L));
         verify(projectTechStackRepository, times(1)).saveAll(any());
     }
 
@@ -228,7 +234,7 @@ class ProjectServiceTest {
     void updateProject_NotFoundProject() {
         //given
 
-        given(projectRepository.findById(anyLong()))
+        given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.empty());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -243,7 +249,7 @@ class ProjectServiceTest {
     void updateProject_NotMatchMemberProject() {
 
         //given
-        given(projectRepository.findById(anyLong()))
+        given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(project));
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -257,7 +263,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 수정 실패 - 해당 기술스택 없음")
     void updateProject_NotFoundTechStack() {
         //given
-        given(projectRepository.findById(anyLong()))
+        given(projectRepository.findByIdQuery(anyLong()))
                 .willReturn(Optional.of(project));
         given(techStackRepository.findAllById(any()))
                 .willReturn(new ArrayList<>());
@@ -338,7 +344,7 @@ class ProjectServiceTest {
                 .role(Role.ROLE_USER)
                 .build());
         //then
-        verify(projectRepository,times(1)).deleteById(project.getId());
+        verify(projectRepository, times(1)).deleteById(project.getId());
     }
 
     @Test
@@ -353,8 +359,9 @@ class ProjectServiceTest {
                 .role(Role.ROLE_ADMIN)
                 .build());
         //then
-        verify(projectRepository,times(1)).deleteById(project.getId());
+        verify(projectRepository, times(1)).deleteById(project.getId());
     }
+
     @Test
     @DisplayName("프로젝트 삭제 실패 - 해당 프로젝트 없음")
     void deleteProject_NotFoundProject() {


### PR DESCRIPTION
**개요**

- #5 
- 프로젝트 수정 오류 해결
- 프로젝트 본인 글 확인 검증 부분 정리

**타입** 

- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [x]  refactor : 코드 리팩토링에 대한 커밋


**작업 사항**
- 모집 기술 스택 ID와 기술 스택 ID를 혼동하여 모집 기술 스택을 지울 때 기술 스택 아이디로 지워서 엉뚱한 값이 지워졌었습니다. 다시 알맞게 넣어 수정했습니다.
- 전에 Project 삭제할 때 ProjectTechStack 정보를 자동으로 지우도록 cascade 설정을 했었는데 수정에서 ProjectTechStack 정보를 지울 때 양방향 매핑으로 인해 project 객체의 projectTechStack 정보도 함께 지워야 하는 상황입니다. 이 과정에서 cascade 설정으로 인해 delete가 중복 실행되어 cascade 설정을 지웠고 Project를 삭제할 때는 명시적으로 ProjectTechStack 정보를 먼저 지우고 Project를 지우도록 변경했습니다
- 실제 기능 부분과 검증하는 부분을 따로 private 메소드로 분리했습니다

**Test**🧪
- 프로젝트 수정할 때 기술 스택이 제대로 변경 되는지 확인했습니다
- 자세한 방식은 테스트 코드에 적어두었습니다
