### PR TITLE
feat: 채팅방 생성 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
+++ b/src/main/java/chocoteamteam/togather/component/security/JwtEntryPoint.java
@@ -44,6 +44,7 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
 				.errorCode(ErrorCode.INVALID_TOKEN)
 				.errorMessage(ErrorCode.INVALID_TOKEN.getErrorMessage())
 				.build();
+			response.setStatus(HttpStatus.UNAUTHORIZED.value());
 		}
 
 		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));

--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -1,0 +1,47 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.ChatRoomDto;
+import chocoteamteam.togather.dto.CreateChatRoomForm;
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.service.ProjectChatRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Tag(name = "Chat", description = "채팅 관련 API")
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+@RestController
+public class ProjectChatRoomController {
+
+	private final ProjectChatRoomService projectChatRoomService;
+
+	@Operation(
+		summary = "채팅방 생성", description = "프로젝트 멤버만 생성 가능, 최대 5개까지 생성 가능",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Chat"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@PostMapping("/{projectId}/chats")
+	public ResponseEntity<ChatRoomDto> createProjectChat(@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable Long projectId,@RequestBody @Valid CreateChatRoomForm form) {
+
+		form.setProjectId(projectId);
+		form.setMemberId(member.getId());
+
+		return ResponseEntity.ok().body(projectChatRoomService.createChatRoom(form));
+	}
+
+
+}

--- a/src/main/java/chocoteamteam/togather/dto/ChatRoomDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ChatRoomDto.java
@@ -1,0 +1,34 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.entity.ChatRoom;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomDto {
+
+	private long roomId;
+	private String roomName;
+
+	public static ChatRoomDto from(ChatRoom entity) {
+		return ChatRoomDto.builder()
+			.roomId(entity.getId())
+			.roomName(entity.getName())
+			.build();
+	}
+
+	public static List<ChatRoomDto> of(List<ChatRoom> entities) {
+		return entities.stream().map(ChatRoomDto::from).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/chocoteamteam/togather/dto/CreateChatRoomForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/CreateChatRoomForm.java
@@ -1,0 +1,21 @@
+package chocoteamteam.togather.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class CreateChatRoomForm {
+	private Long memberId;
+	private Long projectId;
+
+	@NotBlank
+	private String roomName;
+
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/ChatRoom.java
+++ b/src/main/java/chocoteamteam/togather/entity/ChatRoom.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class ChatRoom extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn
+	private Project project;
+
+	@Column(nullable = false)
+	private String name;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/ProjectMember.java
+++ b/src/main/java/chocoteamteam/togather/entity/ProjectMember.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.entity;
+
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class ProjectMember extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn
+	private Project project;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn
+	private Member member;
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/ChatRoomException.java
+++ b/src/main/java/chocoteamteam/togather/exception/ChatRoomException.java
@@ -1,0 +1,19 @@
+package chocoteamteam.togather.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final int status;
+	private final String errorMessage;
+
+	public ChatRoomException(ErrorCode errorCode) {
+		super(errorCode.getErrorMessage());
+		this.errorCode = errorCode;
+		this.status = errorCode.getHttpStatus().value();
+		this.errorMessage = errorCode.getErrorMessage();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -25,11 +25,8 @@ public enum ErrorCode {
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러 입니다."),
     NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다."),
     NOT_PROJECT_MEMBER(HttpStatus.BAD_REQUEST,"프로젝트의 팀원이 아닙니다."),
-    MAXIMUM_CHAT_ROOM(HttpStatus.BAD_REQUEST,"더이상 채팅방을 열 수 없습니다.");
-
-
-    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
-    ;
+    MAXIMUM_CHAT_ROOM(HttpStatus.BAD_REQUEST,"더이상 채팅방을 열 수 없습니다."),
+    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않은 인증 토큰 입니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러 입니다."),
     NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다."),
+    NOT_PROJECT_MEMBER(HttpStatus.BAD_REQUEST,"프로젝트의 팀원이 아닙니다."),
+    MAXIMUM_CHAT_ROOM(HttpStatus.BAD_REQUEST,"더이상 채팅방을 열 수 없습니다.");
 
 
     NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),

--- a/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
@@ -33,4 +33,16 @@ public class GlobalExceptionHandler {
         log.error("{} is occured", e.getErrorCode());
         return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
     }
+
+    @ExceptionHandler(ProjectMemberException.class)
+    public ErrorResponse projectMemberExceptionHandler(ProjectMemberException e) {
+        log.error("{} is occured", e.getErrorCode());
+        return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ExceptionHandler(ChatRoomException.class)
+    public ErrorResponse chatRoomExceptionHandler(ChatRoomException e) {
+        log.error("{} is occured", e.getErrorCode());
+        return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
 }

--- a/src/main/java/chocoteamteam/togather/exception/ProjectMemberException.java
+++ b/src/main/java/chocoteamteam/togather/exception/ProjectMemberException.java
@@ -1,0 +1,19 @@
+package chocoteamteam.togather.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ProjectMemberException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final int status;
+	private final String errorMessage;
+
+	public ProjectMemberException(ErrorCode errorCode) {
+		super(errorCode.getErrorMessage());
+		this.errorCode = errorCode;
+		this.status = errorCode.getHttpStatus().value();
+		this.errorMessage = errorCode.getErrorMessage();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.ChatRoom;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	long countByProject_Id(long projectId);
+}

--- a/src/main/java/chocoteamteam/togather/repository/ProjectMemberRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ProjectMemberRepository.java
@@ -1,0 +1,9 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.ProjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember,Long> {
+
+	boolean existsByProject_IdAndMember_Id(Long projectId, Long memberId);
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -9,6 +9,7 @@ import chocoteamteam.togather.exception.ProjectMemberException;
 import chocoteamteam.togather.repository.ChatRoomRepository;
 import chocoteamteam.togather.repository.ProjectMemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,7 @@ public class ProjectChatRoomService {
 	public ChatRoomDto createChatRoom(@NonNull CreateChatRoomForm form) {
 		authenticateProjectMember(form.getProjectId(), form.getMemberId());
 
-		checkChatRoomMaximum(form);
+		checkChatRoomMaximum(form.getProjectId());
 
 		return ChatRoomDto.from(chatRoomRepository.save(ChatRoom.builder()
 			.project(projectRepository.getReferenceById(form.getProjectId()))
@@ -43,13 +44,9 @@ public class ProjectChatRoomService {
 			throw new ProjectMemberException(ErrorCode.NOT_PROJECT_MEMBER);
 		}
 	}
-	private void checkChatRoomMaximum(CreateChatRoomForm input) {
-		if (chatRoomRepository.countByProject_Id(input.getProjectId()) >= TEAM_CHAT_MAXIMUM) {
+	private void checkChatRoomMaximum(long projectId) {
+		if (chatRoomRepository.countByProject_Id(projectId) >= TEAM_CHAT_MAXIMUM) {
 			throw new ChatRoomException(ErrorCode.MAXIMUM_CHAT_ROOM);
 		}
 	}
-
-
-
-
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -1,0 +1,55 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.ChatRoomDto;
+import chocoteamteam.togather.dto.CreateChatRoomForm;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.exception.ChatRoomException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectMemberException;
+import chocoteamteam.togather.repository.ChatRoomRepository;
+import chocoteamteam.togather.repository.ProjectMemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProjectChatRoomService {
+
+	private static final int TEAM_CHAT_MAXIMUM = 5;
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ProjectRepository projectRepository;
+	private final ProjectMemberRepository projectMemberRepository;
+
+
+	@Transactional
+	public ChatRoomDto createChatRoom(@NonNull CreateChatRoomForm form) {
+		authenticateProjectMember(form.getProjectId(), form.getMemberId());
+
+		checkChatRoomMaximum(form);
+
+		return ChatRoomDto.from(chatRoomRepository.save(ChatRoom.builder()
+			.project(projectRepository.getReferenceById(form.getProjectId()))
+			.name(form.getRoomName())
+			.build()));
+	}
+	private void authenticateProjectMember(Long projectId, Long memberId) {
+		if (!projectMemberRepository.existsByProject_IdAndMember_Id(projectId, memberId)) {
+			throw new ProjectMemberException(ErrorCode.NOT_PROJECT_MEMBER);
+		}
+	}
+	private void checkChatRoomMaximum(CreateChatRoomForm input) {
+		if (chatRoomRepository.countByProject_Id(input.getProjectId()) >= TEAM_CHAT_MAXIMUM) {
+			throw new ChatRoomException(ErrorCode.MAXIMUM_CHAT_ROOM);
+		}
+	}
+
+
+
+
+}

--- a/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
+++ b/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
@@ -1,0 +1,69 @@
+package chocoteamteam.togather.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import chocoteamteam.togather.config.SecurityConfig;
+import chocoteamteam.togather.dto.ChatRoomDto;
+import chocoteamteam.togather.dto.CreateChatRoomForm;
+import chocoteamteam.togather.service.JwtService;
+import chocoteamteam.togather.service.ProjectChatRoomService;
+import chocoteamteam.togather.testUtils.WithLoginMember;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = ProjectChatRoomController.class,
+	includeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+class ProjectChatRoomControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	JwtService jwtService;
+
+	@MockBean
+	ProjectChatRoomService projectChatRoomService;
+
+	@WithLoginMember
+	@DisplayName("채팅방 생성 API 성공")
+	@Test
+	void createProjectChat_success() throws Exception {
+		//given
+		CreateChatRoomForm form = CreateChatRoomForm.builder()
+			.roomName("test").build();
+
+		ChatRoomDto dto = ChatRoomDto.builder()
+			.roomId(1L)
+			.roomName("test")
+			.build();
+
+		given(projectChatRoomService.createChatRoom(any()))
+			.willReturn(dto);
+
+		//when
+		//then
+		mockMvc.perform(post("/projects/1/chats")
+				.content(objectMapper.writeValueAsString(form))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.roomId").value(dto.getRoomId()))
+			.andExpect(jsonPath("$.roomName").value(dto.getRoomName()));
+	}
+}

--- a/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
@@ -1,0 +1,109 @@
+package chocoteamteam.togather.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import chocoteamteam.togather.dto.ChatRoomDto;
+import chocoteamteam.togather.dto.CreateChatRoomForm;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ChatRoomException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectMemberException;
+import chocoteamteam.togather.repository.ChatRoomRepository;
+import chocoteamteam.togather.repository.ProjectMemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectChatRoomServiceTest {
+
+	@Mock
+	ChatRoomRepository chatRoomRepository;
+	@Mock
+	ProjectRepository projectRepository;
+	@Mock
+	ProjectMemberRepository projectMemberRepository;
+
+	@InjectMocks
+	ProjectChatRoomService projectChatRoomService;
+
+	ChatRoom chatRoom;
+	CreateChatRoomForm form;
+
+	@BeforeEach
+	public void init() {
+		chatRoom = ChatRoom.builder()
+			.id(1L)
+			.project(Project.builder().id(1L).build())
+			.name("ChatName")
+			.build();
+
+		form = CreateChatRoomForm.builder()
+			.projectId(1L)
+			.memberId(1L)
+			.roomName("ChatName")
+			.build();
+	}
+
+
+	@DisplayName("프로젝트 채팅방 생성 성공")
+	@Test
+	void createChatRoom_success() {
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
+		given(chatRoomRepository.countByProject_Id(anyLong()))
+			.willReturn(4L);
+		given(chatRoomRepository.save(any()))
+			.willReturn(chatRoom);
+
+		//when
+		ChatRoomDto dto = projectChatRoomService.createChatRoom(form);
+
+		//then
+		assertThat(dto.getRoomId()).isEqualTo(chatRoom.getId());
+		assertThat(dto.getRoomName()).isEqualTo(chatRoom.getName());
+	}
+
+	@DisplayName("프로젝트 채팅방 생성 실패 - 프로젝트 멤버가 아닌데 생성하려는 경우")
+	@Test
+	void createChatRoom_fail_notProjectMember() {
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(false);
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectChatRoomService.createChatRoom(form))
+			.isInstanceOf(ProjectMemberException.class)
+			.hasMessage(ErrorCode.NOT_PROJECT_MEMBER.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 채팅방 생성 실패 - 이미 채팅방을 최대치만큼 생성한 경우")
+	@Test
+	void createChatRoom_fail_maximumChatRoom() {
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
+		given(chatRoomRepository.countByProject_Id(anyLong()))
+			.willReturn(5L);
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectChatRoomService.createChatRoom(form))
+			.isInstanceOf(ChatRoomException.class)
+			.hasMessage(ErrorCode.MAXIMUM_CHAT_ROOM.getErrorMessage());
+	}
+
+
+}


### PR DESCRIPTION
**개요**

- #41
- 채팅방 생성 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- 채팅방 생성 API 를 추가했습니다.
- 채팅방은 오직 프로젝트 팀원만 생성할 수 있도록 했습니다.
- 채팅방 개수는 프로젝트 당 최대 5개 입니다.

**Test**🧪
- 프로젝트 팀원만 채팅방 생성가능한지
- 프로젝트 채팅방 최대 생성치를 넘기면 생성이 안되는지
