### PR TITLE
chore: 프로젝트 정보 가져오는 쿼리 메소드 이름 변경

### DIFF
--- a/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface QueryDslProjectRepository {
     List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition);
 
-    Optional<Project> findByIdQuery(Long projectId);
+    Optional<Project> findByIdWithMemberAndTechStack(Long projectId);
 }

--- a/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
@@ -31,7 +31,7 @@ public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Project> findByIdQuery(Long projectId) {
+    public Optional<Project> findByIdWithMemberAndTechStack(Long projectId) {
         return Optional.ofNullable(jpaQueryFactory
                 .selectFrom(project)
                 .where(project.id.eq(projectId))

--- a/src/main/java/chocoteamteam/togather/service/ProjectService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectService.java
@@ -72,8 +72,7 @@ public class ProjectService {
             UpdateProjectForm form
     ) {
 
-        //프로젝트, 멤버, 모집기술스택, 기술스택 한번에 가져옴
-        Project project = projectRepository.findByIdQuery(projectId)
+        Project project = projectRepository.findByIdWithMemberAndTechStack(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
         validate(project, memberId);
         return updateProject(form, project);
@@ -138,13 +137,13 @@ public class ProjectService {
 
     @Transactional
     public ProjectDetails getProject(Long projectId) {
-        return ProjectDetails.fromEntity(projectRepository.findByIdQuery(projectId)
+        return ProjectDetails.fromEntity(projectRepository.findByIdWithMemberAndTechStack(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT)));
     }
 
     @Transactional
     public ProjectDto deleteProject(Long projectId, Long memberId, Role role) {
-        Project project = projectRepository.findByIdQuery(projectId)
+        Project project = projectRepository.findByIdWithMemberAndTechStack(projectId)
                 .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
 
         if (role != Role.ROLE_ADMIN) {

--- a/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImplTest.java
@@ -18,7 +18,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -114,7 +113,7 @@ class QueryDslProjectRepositoryImplTest {
     void findByIdQueryTest() {
         //given
         //when
-        Project project = projectRepository.findByIdQuery(1L).get();
+        Project project = projectRepository.findByIdWithMemberAndTechStack(1L).get();
 
         //then
         assertEquals(1L, project.getId());

--- a/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectServiceTest.java
@@ -200,7 +200,7 @@ class ProjectServiceTest {
         //새로 입력받은 기술 스택 ID
         List<Long> newTech = new ArrayList<>(List.of(3L, 4L, 5L, 6L));
 
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(testProject));
 
         given(techStackRepository.findAllById(any()))
@@ -231,7 +231,7 @@ class ProjectServiceTest {
     void updateProject_NotFoundProject() {
         //given
 
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.empty());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -246,7 +246,7 @@ class ProjectServiceTest {
     void updateProject_NotMatchMemberProject() {
 
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -260,7 +260,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 수정 실패 - 해당 기술스택 없음")
     void updateProject_NotFoundTechStack() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
         given(techStackRepository.findAllById(any()))
                 .willReturn(new ArrayList<>());
@@ -285,7 +285,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 상세조회 실패")
     void getProject_fail() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.empty());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -314,7 +314,7 @@ class ProjectServiceTest {
         project.addComment(Comment.builder().member(member).id(2L).build());
         project.addComment(Comment.builder().member(member).id(3L).build());
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
 
         //when
@@ -329,7 +329,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 삭제 성공 - 본인 글")
     void deleteProject_MyProject() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
         //when
         projectService.deleteProject(1L, member.getId(), Role.ROLE_USER);
@@ -341,7 +341,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 삭제 성공 - ADMIN")
     void deleteProject_byAdmin() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
         //when
         projectService.deleteProject(3L, 1234L, Role.ROLE_ADMIN);
@@ -353,7 +353,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 삭제 실패 - 해당 프로젝트 없음")
     void deleteProject_NotFoundProject() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.empty());
         //when
         ProjectException exception = assertThrows(ProjectException.class,
@@ -367,7 +367,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트 삭제 실패 - 해당 프로젝트 삭제 권한 없음 (본인 글 x)")
     void deleteProject_NotMyProject() {
         //given
-        given(projectRepository.findByIdQuery(anyLong()))
+        given(projectRepository.findByIdWithMemberAndTechStack(anyLong()))
                 .willReturn(Optional.of(project));
         //when
         ProjectException exception = assertThrows(ProjectException.class,


### PR DESCRIPTION
**개요**

- #5 
- 프로젝트 정보 가져오는 쿼리 메소드 이름 변경

**타입** 

- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)

**작업 사항**
- 프로젝트 정보를 가져올 때 멤버, 모집 기술스택, 기술스택도 함께 가져 왔던 QueryDslProjectRepository의 findByIdQuery를 무슨 정보를 가져오는지 더 명확히 알 수 있도록 findByIdWithMemberAndTechStack으로 변경했습니다
