### PR TITLE
feat: 채팅방 리스트 조회 API 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -7,11 +7,13 @@ import chocoteamteam.togather.service.ProjectChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +44,21 @@ public class ProjectChatRoomController {
 		form.setMemberId(member.getId());
 
 		return ResponseEntity.ok().body(projectChatRoomService.createChatRoom(form));
+	}
+
+	@Operation(
+		summary = "채팅방 조회", description = "프로젝트 멤버만 조회가능",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Chat"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@GetMapping("/{projectId}/chats")
+	public ResponseEntity<List<ChatRoomDto>> getProjectChats(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable long projectId) {
+
+		return ResponseEntity.ok()
+			.body(projectChatRoomService.getChatRooms(projectId, member.getId()));
 	}
 
 

--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -34,8 +34,9 @@ public class ProjectChatRoomController {
 	)
 	@PreAuthorize("hasRole('USER')")
 	@PostMapping("/{projectId}/chats")
-	public ResponseEntity<ChatRoomDto> createProjectChat(@ApiIgnore @AuthenticationPrincipal LoginMember member,
-		@PathVariable Long projectId,@RequestBody @Valid CreateChatRoomForm form) {
+	public ResponseEntity<ChatRoomDto> createProjectChat(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable long projectId, @RequestBody @Valid CreateChatRoomForm form) {
 
 		form.setProjectId(projectId);
 		form.setMemberId(member.getId());

--- a/src/main/java/chocoteamteam/togather/dto/CreateChatRoomForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/CreateChatRoomForm.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @Data
 public class CreateChatRoomForm {
-	private Long memberId;
-	private Long projectId;
+	private long memberId;
+	private long projectId;
 
 	@NotBlank
 	private String roomName;

--- a/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	long countByProject_Id(long projectId);
+
+	List<ChatRoom> findByProject_Id(long projectId);
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -39,7 +39,7 @@ public class ProjectChatRoomService {
 			.name(form.getRoomName())
 			.build()));
 	}
-	private void authenticateProjectMember(Long projectId, Long memberId) {
+	private void authenticateProjectMember(long projectId, long memberId) {
 		if (!projectMemberRepository.existsByProject_IdAndMember_Id(projectId, memberId)) {
 			throw new ProjectMemberException(ErrorCode.NOT_PROJECT_MEMBER);
 		}

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -49,4 +49,12 @@ public class ProjectChatRoomService {
 			throw new ChatRoomException(ErrorCode.MAXIMUM_CHAT_ROOM);
 		}
 	}
+
+	@Transactional(readOnly = true)
+	public List<ChatRoomDto> getChatRooms(long projectId, long memberId) {
+		authenticateProjectMember(projectId,memberId);
+
+		return ChatRoomDto.of(chatRoomRepository.findByProject_Id(projectId));
+	}
+
 }

--- a/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
+++ b/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
@@ -1,7 +1,11 @@
 package chocoteamteam.togather.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,8 +18,11 @@ import chocoteamteam.togather.service.JwtService;
 import chocoteamteam.togather.service.ProjectChatRoomService;
 import chocoteamteam.togather.testUtils.WithLoginMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -65,5 +72,38 @@ class ProjectChatRoomControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.roomId").value(dto.getRoomId()))
 			.andExpect(jsonPath("$.roomName").value(dto.getRoomName()));
+	}
+
+	@WithLoginMember
+	@DisplayName("채팅방 리스트 조회 API 성공")
+	@Test
+	void getProjectChats_success() throws Exception {
+		//given
+		ChatRoomDto dto = ChatRoomDto.builder()
+			.roomId(1L)
+			.roomName("test")
+			.build();
+
+		List<ChatRoomDto> chatRoomDtos = Arrays.asList(dto);
+
+		given(projectChatRoomService.getChatRooms(anyLong(), anyLong()))
+			.willReturn(chatRoomDtos);
+
+		ArgumentCaptor<Long> memberIdCaptor = ArgumentCaptor.forClass(Long.class);
+		ArgumentCaptor<Long> projectIdCaptor = ArgumentCaptor.forClass(Long.class);
+
+		//when
+		//then
+		mockMvc.perform(get("/projects/1/chats"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].roomId").value(dto.getRoomId()))
+			.andExpect(jsonPath("$[0].roomName").value(dto.getRoomName()));
+
+		verify(projectChatRoomService)
+			.getChatRooms(projectIdCaptor.capture(), memberIdCaptor.capture());
+
+		assertThat(projectIdCaptor.getValue()).isEqualTo(1L);
+		assertThat(memberIdCaptor.getValue()).isEqualTo(1L);
 	}
 }

--- a/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
@@ -16,6 +16,8 @@ import chocoteamteam.togather.exception.ProjectMemberException;
 import chocoteamteam.togather.repository.ChatRoomRepository;
 import chocoteamteam.togather.repository.ProjectMemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,7 +77,7 @@ class ProjectChatRoomServiceTest {
 		assertThat(dto.getRoomName()).isEqualTo(chatRoom.getName());
 	}
 
-	@DisplayName("프로젝트 채팅방 생성 실패 - 프로젝트 멤버가 아닌데 생성하려는 경우")
+	@DisplayName("프로젝트 채팅방 생성 실패 - 프로젝트 멤버가 아닌 경우")
 	@Test
 	void createChatRoom_fail_notProjectMember() {
 		//given
@@ -103,6 +105,40 @@ class ProjectChatRoomServiceTest {
 		assertThatThrownBy(() -> projectChatRoomService.createChatRoom(form))
 			.isInstanceOf(ChatRoomException.class)
 			.hasMessage(ErrorCode.MAXIMUM_CHAT_ROOM.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 채팅방 리스트 조회 성공")
+	@Test
+	void getChatRooms_success(){
+	    //given
+		List<ChatRoom> list = Arrays.asList(chatRoom);
+
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
+		given(chatRoomRepository.findByProject_Id(anyLong()))
+			.willReturn(list);
+
+	    //when
+		List<ChatRoomDto> chatRooms = projectChatRoomService.getChatRooms(1L, 1L);
+
+		//then
+		assertThat(chatRooms.size()).isEqualTo(list.size());
+		assertThat(chatRooms.get(0).getRoomId()).isEqualTo(chatRoom.getId());
+		assertThat(chatRooms.get(0).getRoomName()).isEqualTo(chatRoom.getName());
+	}
+
+	@DisplayName("프로젝트 채팅방 리스트 조회 실패 - 프로젝트 멤버가 아닌 경우")
+	@Test
+	void getChatRooms_fail_notProjectMember(){
+	    //given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(false);
+
+	    //when
+		//then
+		assertThatThrownBy(() -> projectChatRoomService.getChatRooms(1L, 1L))
+			.isInstanceOf(ProjectMemberException.class)
+			.hasMessage(ErrorCode.NOT_PROJECT_MEMBER.getErrorMessage());
 	}
 
 


### PR DESCRIPTION
**개요**

- #41 
- 채팅방 리스트 조회 API 구현

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 프로젝트의 채팅방 리스트를 조회할 수 있는 API를 구현했습니다.

**Test**🧪
- 정상적으로 입력, 출력되는지 테스트
- Pathvaraible과 AuthenticationPrinciapl등이 정상적으로 넘어가는지 테스트
