### PR TITLE
test: OAuthServiceTest 회원가입 실패 테스트 수정

### DIFF
--- a/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/OAuthServiceTest.java
@@ -12,6 +12,7 @@ import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.MemberTechStack;
 import chocoteamteam.togather.entity.TechStack;
 import chocoteamteam.togather.exception.CustomOAuthException;
+import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.TechStackException;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.MemberTechStackRepository;
@@ -138,7 +139,7 @@ class OAuthServiceTest {
                 .techStackDtoList(techStackDtos)
                 .build()))
             .isInstanceOf(TechStackException.class)
-            .hasMessage("기술이 존재하지 않습니다.");
+            .hasMessage(ErrorCode.NOT_FOUND_TECH_STACK.getErrorMessage());
     }
 
     @DisplayName("회원 가입 실패 - 이미 존재하는 닉네임")
@@ -165,7 +166,7 @@ class OAuthServiceTest {
                 .techStackDtoList(techStackDtos)
                 .build()))
             .isInstanceOf(CustomOAuthException.class)
-            .hasMessage("이미 존재하는 닉네임입니다.");
+            .hasMessage(ErrorCode.EXIST_TRUE_MEMBER_NICKNAME.getErrorMessage());
     }
 
 }


### PR DESCRIPTION
**개요**
- test: OAuthServiceTest 회원가입 실패 테스트 에러메시지 비교 부분 수정


**타입** 
- [x]  test : 테스트 코드 수정에 대한 커밋


**작업 사항**
- 예외 처리 통일하기 전 실패 테스트에서 예외 메시지 비교하는 부분들을 ErrorCode의 ErrorMessage를 가져와 비교하도록 했습니다.
