### PR TITLE
feat: 채팅방 상세조회 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -1,5 +1,7 @@
 package chocoteamteam.togather.controller;
 
+import chocoteamteam.togather.dto.ChatDetailDto;
+import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
 import chocoteamteam.togather.dto.CreateChatRoomForm;
 import chocoteamteam.togather.dto.LoginMember;
@@ -47,7 +49,7 @@ public class ProjectChatRoomController {
 	}
 
 	@Operation(
-		summary = "채팅방 조회", description = "프로젝트 멤버만 조회가능",
+		summary = "채팅방 리스트 조회", description = "프로젝트 멤버만 조회가능",
 		security = {@SecurityRequirement(name = "Authorization")},
 		tags = {"Chat"}
 	)
@@ -60,6 +62,24 @@ public class ProjectChatRoomController {
 		return ResponseEntity.ok()
 			.body(projectChatRoomService.getChatRooms(projectId, member.getId()));
 	}
+
+	// 채팅방 상세조회
+	@Operation(
+		summary = "채팅방 상세 조회", description = "프로젝트 멤버만 조회가능, 메시지들도 함께 조회",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Chat"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@GetMapping("/{projectId}/chats/{chatId}")
+	public ResponseEntity<ChatDetailDto> getProjectChat(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable long projectId, @PathVariable long chatId) {
+
+		return ResponseEntity.ok()
+			.body(projectChatRoomService
+				.getChatRoom(projectId, member.getId(), chatId));
+	}
+
 
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/ChatDetailDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ChatDetailDto.java
@@ -1,0 +1,16 @@
+package chocoteamteam.togather.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ChatDetailDto {
+	private long roomId;
+	private List<ChatMessageDto> messages;
+}

--- a/src/main/java/chocoteamteam/togather/dto/ChatMessageDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ChatMessageDto.java
@@ -1,0 +1,20 @@
+package chocoteamteam.togather.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ChatMessageDto {
+
+	private String nickname;
+	private String profileImage;
+	private String message;
+	private LocalDateTime time;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/ChatMessage.java
+++ b/src/main/java/chocoteamteam/togather/entity/ChatMessage.java
@@ -1,0 +1,35 @@
+package chocoteamteam.togather.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class ChatMessage extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@JoinColumn
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@JoinColumn
+	private Member sender;
+
+	private String message;
+}

--- a/src/main/java/chocoteamteam/togather/repository/ChatMessageRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.ChatMessage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ChatRoomRepository.java
@@ -8,5 +8,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	long countByProject_Id(long projectId);
 
-	List<ChatRoom> findByProject_Id(long projectId);
+	List<ChatRoom> findAllByProject_Id(long projectId);
 }

--- a/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
@@ -1,0 +1,38 @@
+package chocoteamteam.togather.repository.impl;
+
+import static chocoteamteam.togather.entity.QChatMessage.chatMessage;
+import static chocoteamteam.togather.entity.QMember.member;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Repository
+@Transactional
+public class QuerydslChatRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<ChatMessageDto> findAllByChatRoomId(long chatRoomId) {
+		List<ChatMessageDto> result = jpaQueryFactory.select(
+				Projections.fields(ChatMessageDto.class,
+					member.nickname.as("nickname"),
+					member.profileImage.as("profileImage"),
+					chatMessage.message.as("message"),
+					chatMessage.createdAt.as("time")
+				)).from(chatMessage)
+			.innerJoin(chatMessage.sender, member)
+			.where(chatMessage.chatRoom.id.eq(chatRoomId))
+			.orderBy(chatMessage.createdAt.desc())
+			.limit(1000)
+			.fetch();
+
+		return result;
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.service;
 
+import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
 import chocoteamteam.togather.dto.CreateChatRoomForm;
 import chocoteamteam.togather.entity.ChatRoom;
@@ -9,6 +10,7 @@ import chocoteamteam.togather.exception.ProjectMemberException;
 import chocoteamteam.togather.repository.ChatRoomRepository;
 import chocoteamteam.togather.repository.ProjectMemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.impl.QuerydslChatRepository;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class ProjectChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ProjectRepository projectRepository;
 	private final ProjectMemberRepository projectMemberRepository;
+	private final QuerydslChatRepository querydslChatRepository;
 
 
 	@Transactional
@@ -55,6 +58,17 @@ public class ProjectChatRoomService {
 		authenticateProjectMember(projectId,memberId);
 
 		return ChatRoomDto.of(chatRoomRepository.findByProject_Id(projectId));
+	}
+
+	@Transactional(readOnly = true)
+	public ChatDetailDto getChatRoom(long projectId, long memberId, long chatRoomId) {
+		authenticateProjectMember(projectId, memberId);
+
+		return ChatDetailDto.builder()
+			.roomId(chatRoomId)
+			.messages(querydslChatRepository.findAllByChatRoomId(chatRoomId))
+			.build();
+
 	}
 
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -57,7 +57,7 @@ public class ProjectChatRoomService {
 	public List<ChatRoomDto> getChatRooms(long projectId, long memberId) {
 		authenticateProjectMember(projectId,memberId);
 
-		return ChatRoomDto.of(chatRoomRepository.findByProject_Id(projectId));
+		return ChatRoomDto.of(chatRoomRepository.findAllByProject_Id(projectId));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -44,7 +44,7 @@ public class ProjectChatRoomService {
 	}
 	private void authenticateProjectMember(long projectId, long memberId) {
 		if (!projectMemberRepository.existsByProject_IdAndMember_Id(projectId, memberId)) {
-			throw new ProjectMemberException(ErrorCode.NOT_PROJECT_MEMBER);
+			throw new ProjectMemberException(ErrorCode.NO_PERMISSION);
 		}
 	}
 	private void checkChatRoomMaximum(long projectId) {
@@ -64,8 +64,16 @@ public class ProjectChatRoomService {
 	public ChatDetailDto getChatRoom(long projectId, long memberId, long chatRoomId) {
 		authenticateProjectMember(projectId, memberId);
 
+		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+			.orElseThrow(() -> new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM));
+
+		if (projectId != chatRoom.getProject().getId()) {
+			throw new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM);
+		}
+
 		return ChatDetailDto.builder()
 			.roomId(chatRoomId)
+			.roomName(chatRoom.getName())
 			.messages(querydslChatRepository.findAllByChatRoomId(chatRoomId))
 			.build();
 

--- a/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
+++ b/src/test/java/chocoteamteam/togather/controller/ProjectChatRoomControllerTest.java
@@ -12,6 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import chocoteamteam.togather.config.SecurityConfig;
+import chocoteamteam.togather.dto.ChatDetailDto;
+import chocoteamteam.togather.dto.ChatMessageDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
 import chocoteamteam.togather.dto.CreateChatRoomForm;
 import chocoteamteam.togather.service.JwtService;
@@ -106,4 +108,38 @@ class ProjectChatRoomControllerTest {
 		assertThat(projectIdCaptor.getValue()).isEqualTo(1L);
 		assertThat(memberIdCaptor.getValue()).isEqualTo(1L);
 	}
+
+	@WithLoginMember
+	@DisplayName("채팅방 상세 조회 API 성공")
+	@Test
+	void getProjectChat_success() throws Exception {
+		//given
+		ChatMessageDto message = ChatMessageDto.builder()
+			.message("test")
+			.nickname("tester")
+			.build();
+
+		List<ChatMessageDto> messages = Arrays.asList(message);
+
+		ChatDetailDto dto = ChatDetailDto.builder()
+			.roomId(1L)
+			.messages(messages)
+			.build();
+
+
+		given(projectChatRoomService.getChatRoom(anyLong(), anyLong(),anyLong()))
+			.willReturn(dto);
+
+		//when
+		//then
+		mockMvc.perform(get("/projects/1/chats/1"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.roomId").value(dto.getRoomId()))
+			.andExpect(jsonPath("$.messages[0].message").value(message.getMessage()))
+			.andExpect(jsonPath("$.messages[0].nickname").value(message.getNickname()));
+
+	}
+
+
 }

--- a/src/test/java/chocoteamteam/togather/repository/impl/QuerydslChatRepositoryTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QuerydslChatRepositoryTest.java
@@ -1,0 +1,98 @@
+package chocoteamteam.togather.repository.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.entity.ChatMessage;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.repository.ChatMessageRepository;
+import chocoteamteam.togather.repository.ChatRoomRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import({QueryDslTestConfig.class,QuerydslChatRepository.class})
+@DataJpaTest
+class QuerydslChatRepositoryTest {
+
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	ProjectRepository projectRepository;
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+	@Autowired
+	ChatMessageRepository chatMessageRepository;
+	@Autowired
+	QuerydslChatRepository querydslChatRepository;
+
+	Member member;
+
+	@BeforeAll
+	@Transactional
+	public void beforeAll() {
+		member = Member.builder()
+			.status(MemberStatus.PERMITTED)
+			.role(Role.ROLE_USER)
+			.email("test@test.com")
+			.profileImage("noImage")
+			.providerType(ProviderType.KAKAO)
+			.nickname("tester")
+			.build();
+
+		memberRepository.save(member);
+
+		Project project = Project.builder()
+			.member(member)
+			.build();
+
+		projectRepository.save(project);
+
+		ChatRoom chatRoom = ChatRoom.builder()
+			.project(project)
+			.name("testChatRoom")
+			.build();
+
+		chatRoomRepository.save(chatRoom);
+
+		for (int i = 0; i < 10000; i++) {
+			ChatMessage chatMessage = ChatMessage.builder()
+				.chatRoom(chatRoom)
+				.sender(member)
+				.message("test")
+				.build();
+
+			chatMessageRepository.save(chatMessage);
+		}
+	}
+	@DisplayName("채팅방 채팅메시지 조회 성공 - 최신순으로, 최대 1000건")
+	@Test
+	@Transactional
+	void findAllByTeamId_success() {
+
+		List<ChatMessageDto> result = querydslChatRepository.findAllByChatRoomId(1L);
+		ChatMessageDto chatMessageDto = result.get(0);
+
+		assertThat(result.size()).isEqualTo(1000);
+		assertThat(chatMessageDto.getNickname()).isEqualTo(member.getNickname());
+		assertThat(chatMessageDto.getProfileImage()).isEqualTo(member.getProfileImage());
+		assertThat(chatMessageDto.getMessage()).isEqualTo("test");
+	}
+}


### PR DESCRIPTION
**개요**

- #41 
- 채팅방 상세조회 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 채팅방 메세지 엔티티를 추가
- 채팅방 상세 조회 시, 최대 1000건,최신순으로 메세지 가져오도록 구현

**Test**🧪
- 테스트 코드 의도는 커밋메세지나 DisplayName을 참고해주세요!
