### PR TITLE
feat: 채팅방 이름 변경 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.controller;
 
+import chocoteamteam.togather.dto.ChangeChatRoomNameForm;
 import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
@@ -18,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -80,6 +82,26 @@ public class ProjectChatRoomController {
 				.getChatRoom(projectId, member.getId(), chatId));
 	}
 
+	@Operation(
+		summary = "채팅방 이름 수정", description = "채팅방 이름 수정",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Chat"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@PutMapping("/{projectId}/chats/{chatId}")
+	public ResponseEntity changeProjectChatName(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable long projectId, @PathVariable long chatId,
+		@RequestBody ChangeChatRoomNameForm form) {
+
+		form.setProjectId(projectId);
+		form.setMemberId(member.getId());
+		form.setRoomId(chatId);
+
+		projectChatRoomService.changeChatRoomName(form);
+
+		return ResponseEntity.ok().body("");
+	}
 
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/ChangeChatRoomNameForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/ChangeChatRoomNameForm.java
@@ -1,17 +1,20 @@
 package chocoteamteam.togather.dto;
 
-import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 @Builder
 @Data
-public class ChatDetailDto {
+public class ChangeChatRoomNameForm {
+	private long projectId;
+	private long memberId;
 	private long roomId;
+
+	@NotBlank
 	private String roomName;
-	private List<ChatMessageDto> messages;
 }

--- a/src/main/java/chocoteamteam/togather/entity/ChatRoom.java
+++ b/src/main/java/chocoteamteam/togather/entity/ChatRoom.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,4 +33,7 @@ public class ChatRoom extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String name;
 
+	public void changeName(String name) {
+		this.name = name;
+	}
 }

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
     NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다."),
     NOT_PROJECT_MEMBER(HttpStatus.BAD_REQUEST,"프로젝트의 팀원이 아닙니다."),
     MAXIMUM_CHAT_ROOM(HttpStatus.BAD_REQUEST,"더이상 채팅방을 열 수 없습니다."),
-    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다.");
+    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
+    NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST,"찾을 수 없는 채팅방입니다."),
+    CHATROOM_NOT_MATCHED_PROJECT(HttpStatus.BAD_REQUEST,"프로젝트에 없는 채팅방입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.service;
 
+import chocoteamteam.togather.dto.ChangeChatRoomNameForm;
 import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
 import chocoteamteam.togather.dto.CreateChatRoomForm;
@@ -64,12 +65,7 @@ public class ProjectChatRoomService {
 	public ChatDetailDto getChatRoom(long projectId, long memberId, long chatRoomId) {
 		authenticateProjectMember(projectId, memberId);
 
-		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-			.orElseThrow(() -> new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM));
-
-		if (projectId != chatRoom.getProject().getId()) {
-			throw new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM);
-		}
+		ChatRoom chatRoom = getProjectChat(projectId, chatRoomId);
 
 		return ChatDetailDto.builder()
 			.roomId(chatRoomId)
@@ -77,6 +73,25 @@ public class ProjectChatRoomService {
 			.messages(querydslChatRepository.findAllByChatRoomId(chatRoomId))
 			.build();
 
+	}
+
+	@Transactional
+	public void changeChatRoomName(ChangeChatRoomNameForm form) {
+		authenticateProjectMember(form.getProjectId(), form.getMemberId());
+
+		ChatRoom chatRoom = getProjectChat(form.getProjectId(), form.getRoomId());
+
+		chatRoom.changeName(form.getRoomName());
+	}
+
+	private ChatRoom getProjectChat(long projectId, long chatRoomId) {
+		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+			.orElseThrow(() -> new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM));
+
+		if (projectId != chatRoom.getProject().getId()) {
+			throw new ChatRoomException(ErrorCode.CHATROOM_NOT_MATCHED_PROJECT);
+		}
+		return chatRoom;
 	}
 
 }

--- a/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectChatRoomServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
+import chocoteamteam.togather.dto.ChangeChatRoomNameForm;
 import chocoteamteam.togather.dto.ChatDetailDto;
 import chocoteamteam.togather.dto.ChatMessageDto;
 import chocoteamteam.togather.dto.ChatRoomDto;
@@ -225,8 +226,76 @@ class ProjectChatRoomServiceTest {
 			.hasMessage(ErrorCode.CHATROOM_NOT_MATCHED_PROJECT.getErrorMessage());
 	}
 
+	@DisplayName("프로젝트 채팅방 이름 변경 성공")
+	@Test
+	void changeChatRoomName_success(){
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
+		given(chatRoomRepository.findById(anyLong()))
+			.willReturn(Optional.of(chatRoom));
+
+		ChangeChatRoomNameForm form = ChangeChatRoomNameForm.builder()
+			.roomId(1L)
+			.memberId(1L)
+			.projectId(1L)
+			.roomName("change")
+			.build();
+
+		//when
+		projectChatRoomService.changeChatRoomName(form);
+
+		//then
+		assertThat(chatRoom.getName()).isEqualTo(form.getRoomName());
+	}
+
+	@DisplayName("프로젝트 채팅방 이름 변경 실패 - 채팅방이 존재하지 않는 경우")
+	@Test
+	void changeChatRoomName_fail_notFoundChatRoom(){
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
+
+		given(chatRoomRepository.findById(anyLong()))
+			.willReturn(Optional.empty());
+
+		ChangeChatRoomNameForm form = ChangeChatRoomNameForm.builder()
+			.roomId(1L)
+			.memberId(1L)
+			.projectId(1L)
+			.roomName("change")
+			.build();
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectChatRoomService.changeChatRoomName(form))
+			.isInstanceOf(ChatRoomException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_CHATROOM.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 채팅방 이름 변경 실패 - 요청한 채팅방이 프로젝트의 채팅방이 아닌 경우")
+	@Test
+	void changeChatRoomName_fail_chatroomNotMatchedProject(){
+		//given
+		given(projectMemberRepository.existsByProject_IdAndMember_Id(anyLong(), anyLong()))
+			.willReturn(true);
 
 
+		given(chatRoomRepository.findById(anyLong()))
+			.willReturn(Optional.of(chatRoom));
 
+		ChangeChatRoomNameForm form = ChangeChatRoomNameForm.builder()
+			.roomId(1L)
+			.memberId(1L)
+			.projectId(2L)
+			.roomName("change")
+			.build();
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectChatRoomService.changeChatRoomName(form))
+			.isInstanceOf(ChatRoomException.class)
+			.hasMessage(ErrorCode.CHATROOM_NOT_MATCHED_PROJECT.getErrorMessage());
+	}
 
 }


### PR DESCRIPTION
**개요**

- #41 
- 채팅방 이름 변경 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- 채팅방 이름 변경 API를 구현했습니다.
- 채팅방 이름 변경 시, 요청한 회원이 프로젝트 멤버인지, 요청한 채팅방이 프로젝트가 가지고 있는 채팅방인지 검증하는 로직이 들어가있어 체크하고 있습니다. 

**Test**🧪
- 채팅방 이름이 잘 변경되는지 테스트 진행했습니다.
- 컨트롤러에는 큰 로직이 없어서 테스트를 진행하지 않았습니다.
