### PR TITLE
feat: 채팅방 삭제 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectChatRoomController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -99,6 +100,22 @@ public class ProjectChatRoomController {
 		form.setRoomId(chatId);
 
 		projectChatRoomService.changeChatRoomName(form);
+
+		return ResponseEntity.ok().body("");
+	}
+
+	@Operation(
+		summary = "채팅방 삭제", description = "채팅방 삭제 시, 저장된 메시지도 함께 삭제",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"Chat"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@DeleteMapping("/{projectId}/chats/{chatId}")
+	public ResponseEntity deleteProjectChat(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable long projectId, @PathVariable long chatId) {
+
+		projectChatRoomService.deleteChatRoom(projectId, member.getId(), chatId);
 
 		return ResponseEntity.ok().body("");
 	}

--- a/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
@@ -4,12 +4,16 @@ import static chocoteamteam.togather.entity.QChatMessage.chatMessage;
 import static chocoteamteam.togather.entity.QMember.member;
 
 import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.entity.QChatMessage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @RequiredArgsConstructor
 @Repository
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuerydslChatRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
+	private final EntityManager entityManager;
 
 	public List<ChatMessageDto> findAllByChatRoomId(long chatRoomId) {
 		List<ChatMessageDto> result = jpaQueryFactory.select(
@@ -34,5 +39,22 @@ public class QuerydslChatRepository {
 
 		return result;
 	}
+
+	public long deleteAllByChatRoomId(long chatRoomId) {
+		QChatMessage subChatMessage = new QChatMessage("subChatMessage");
+
+		long deleteCnt = jpaQueryFactory.delete(chatMessage)
+			.where(chatMessage.id.in(JPAExpressions.select(subChatMessage.id)
+				.from(subChatMessage)
+				.where(subChatMessage.chatRoom.id.eq(chatRoomId))))
+			.execute();
+
+		entityManager.flush();
+		entityManager.clear();
+
+		return deleteCnt;
+	}
+
+
 
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectChatRoomService.java
@@ -84,6 +84,16 @@ public class ProjectChatRoomService {
 		chatRoom.changeName(form.getRoomName());
 	}
 
+	@Transactional
+	public void deleteChatRoom(long projectId, long memberId, long chatRoomId) {
+		authenticateProjectMember(projectId, memberId);
+
+		ChatRoom chatRoom = getProjectChat(projectId, chatRoomId);
+
+		querydslChatRepository.deleteAllByChatRoomId(chatRoomId);
+		chatRoomRepository.delete(chatRoom);
+	}
+
 	private ChatRoom getProjectChat(long projectId, long chatRoomId) {
 		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
 			.orElseThrow(() -> new ChatRoomException(ErrorCode.NOT_FOUND_CHATROOM));

--- a/src/test/java/chocoteamteam/togather/repository/impl/QuerydslChatRepositoryTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QuerydslChatRepositoryTest.java
@@ -18,15 +18,20 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Import({QueryDslTestConfig.class,QuerydslChatRepository.class})
 @DataJpaTest
@@ -84,6 +89,7 @@ class QuerydslChatRepositoryTest {
 	}
 	@DisplayName("채팅방 채팅메시지 조회 성공 - 최신순으로, 최대 1000건")
 	@Test
+	@Order(1)
 	@Transactional
 	void findAllByTeamId_success() {
 
@@ -95,4 +101,16 @@ class QuerydslChatRepositoryTest {
 		assertThat(chatMessageDto.getProfileImage()).isEqualTo(member.getProfileImage());
 		assertThat(chatMessageDto.getMessage()).isEqualTo("test");
 	}
+
+	@DisplayName("채팅방 채팅메시지 삭제 성공")
+	@Test
+	@Order(2)
+	@Transactional
+	void deleteAllByChatRoomId_success() {
+
+		long delCnt = querydslChatRepository.deleteAllByChatRoomId(1L);
+
+		assertThat(delCnt).isEqualTo(10000);
+	}
+
 }


### PR DESCRIPTION
**개요**

- Closes #41 
- feat: 채팅방 삭제 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 채팅방 삭제 시, 채팅메시지도 같이 삭제되도록 구현했습니다.

**Test**🧪
- Querydsl 삭제 성능 테스트
