### PR TITLE
fix: SNS 로그인 Github일 경우 공개된 메일 없을 경우 발생하는 에러 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     MEMBER_STATUS_WITHDRAWAL(HttpStatus.UNAUTHORIZED, "탈퇴한 회원입니다."),
     ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "비정상적인 접근입니다."),
 
+    EXIST_FALSE_GITHUB_EMAIL(HttpStatus.BAD_REQUEST,"Github의 공개된 이메일이 존재하지 않습니다."),
     MISS_MATCH_MEMBER(HttpStatus.BAD_REQUEST, "본인 정보만 수정할 수 있습니다."),
     EXIST_TRUE_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     MISS_MATCH_PROVIDER(HttpStatus.BAD_REQUEST, "다른 SNS 계정으로 회원가입이 돼있습니다."),

--- a/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GithubOAuth2MemberInfo.java
@@ -18,6 +18,6 @@ public class GithubOAuth2MemberInfo extends OAuth2MemberInfo {
     }
 
     public Optional<String> getEmail() {
-        return Optional.of((String) attributes.get("email"));
+        return Optional.ofNullable((String) attributes.get("email"));
     }
 }

--- a/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/GoogleOAuth2MemberInfo.java
@@ -18,6 +18,6 @@ public class GoogleOAuth2MemberInfo extends OAuth2MemberInfo {
     }
 
     public Optional<String> getEmail() {
-        return Optional.of((String)attributes.get("email"));
+        return Optional.ofNullable((String)attributes.get("email"));
     }
 }

--- a/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/KakaoOAuth2MemberInfo.java
@@ -20,6 +20,6 @@ public class KakaoOAuth2MemberInfo extends OAuth2MemberInfo {
 
     public Optional<String> getEmail() {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        return Optional.of((String) kakaoAccount.get("email"));
+        return Optional.ofNullable((String) kakaoAccount.get("email"));
     }
 }

--- a/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
+++ b/src/main/java/chocoteamteam/togather/oauth2/NaverOAuth2MemberInfo.java
@@ -21,6 +21,6 @@ public class NaverOAuth2MemberInfo extends OAuth2MemberInfo {
 
     public Optional<String> getEmail() {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-        return Optional.of((String) response.get("email"));
+        return Optional.ofNullable((String) response.get("email"));
     }
 }


### PR DESCRIPTION
**개요**
- SNS 로그인 Github일 경우 공개된 메일 없을 경우 발생하는 에러 추가

**타입** 
- [x]  fix : 버그 수정이나 로직 변경 등의 수정

**작업 사항**
- 깃허브의 경우 개인이 공개메일을 설정하지 않으면 가져오지 못하는데 이에 발생하는 예외를 추가했습니다.

**Test**🧪
- 깃허브 공개메일을 설정하지 않은 경우 설정한 예외가 발생하는지 간단하게 postman으로 테스트 했습니다.

**Others - optional**
![image](https://user-images.githubusercontent.com/71117490/192246044-39e85c50-fb40-413c-8047-d056521b24a2.png)
