### PR TITLE
feat: 채팅 시, JWT 인증 기능 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/component/stomp/ChatErrorHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/stomp/ChatErrorHandler.java
@@ -1,0 +1,59 @@
+package chocoteamteam.togather.component.stomp;
+
+import chocoteamteam.togather.dto.ErrorResponse;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.TokenException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChatErrorHandler extends StompSubProtocolErrorHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage,
+		Throwable ex) {
+
+		if (ex.getCause() instanceof TokenException) {
+			TokenException exception = (TokenException) ex.getCause();
+
+			return prepareErrorMessage(exception.getErrorCode());
+
+		}
+
+		return super.handleClientMessageProcessingError(clientMessage, ex);
+	}
+
+	private Message<byte[]> prepareErrorMessage(ErrorCode errorCode) {
+
+		ErrorResponse response = ErrorResponse.builder()
+			.errorMessage(errorCode.getErrorMessage())
+			.errorCode(errorCode)
+			.status(errorCode.getHttpStatus().value())
+			.build();
+
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+
+		accessor.setMessage(errorCode.name());
+		accessor.setLeaveMutable(true);
+
+		try {
+			return MessageBuilder.createMessage(objectMapper.writeValueAsString(response).getBytes(),
+				accessor.getMessageHeaders());
+		} catch (JsonProcessingException e) {
+			return MessageBuilder.createMessage(errorCode.name().getBytes(),
+				accessor.getMessageHeaders());
+		}
+	}
+}

--- a/src/main/java/chocoteamteam/togather/component/stomp/StompJwtHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/stomp/StompJwtHandler.java
@@ -1,0 +1,49 @@
+package chocoteamteam.togather.component.stomp;
+
+import chocoteamteam.togather.dto.TokenMemberInfo;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.TokenException;
+import chocoteamteam.togather.service.JwtService;
+import com.sun.security.auth.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@Component
+public class StompJwtHandler implements ChannelInterceptor {
+
+	private final JwtService jwtService;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message,
+			StompHeaderAccessor.class);
+
+		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+			try {
+				TokenMemberInfo info = jwtService.parseAccessToken(
+					accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION).substring(7));
+
+				log.info("Member connected WebSocket. id : {} , name : {}",info.getId(),info.getNickname());
+
+				accessor.setUser(new UserPrincipal(String.valueOf(info.getId())));
+			} catch (Exception e) {
+				throw new TokenException(ErrorCode.INVALID_TOKEN,e);
+			}
+		}
+
+		return message;
+	}
+}

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -24,4 +24,8 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/app");
         registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
     }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompJwtHandler);
+    }
 }

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -16,6 +16,7 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/stomp/chat")
             .setAllowedOrigins("http://*.*.*.*:8080")
             .withSockJS();
+        registry.setErrorHandler(chatErrorHandler);
     }
 
     @Override


### PR DESCRIPTION
**개요**

- #53 
- 채팅 시, JWT 인증 기능 구현

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- WebSocket에서 STOMP 를 이용하여 서버와 연결할 때 (CONNECT frame), Authorization 헤더를 통해 회원 인증하는 기능을 추가했습니다. 
- 인증 시 발생하는 오류에 대한 예외처리도 함께 진행했습니다.

**Test**🧪
- Apic 라는 크롬 브라우저 툴로 테스트 진행했습니다.
- 제대로 로그인된 정보가 로그에 찍히는지 테스트
![image](https://user-images.githubusercontent.com/87813831/192591782-fe5f5399-aacc-41c8-8571-7f013f799b12.png)
- 토큰없이 연결하려할 때, 오류 메시지 전송
![image](https://user-images.githubusercontent.com/87813831/192591953-8f9120b0-0a7d-4a05-b978-fe54a33e2d7f.png)

**Others**
- @MessagMapping 가 적용되는 method에서 parameter로 Principal을 가져올 수 있는데, getName() 의 값으로 memberId 값이 반환됩니다.