### PR TITLE
feat: 팀 채팅 전송 기능 구현

### DIFF
--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -1,6 +1,10 @@
 package chocoteamteam.togather.config;
 
+import chocoteamteam.togather.component.stomp.ChatErrorHandler;
+import chocoteamteam.togather.component.stomp.StompJwtHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;

--- a/src/main/java/chocoteamteam/togather/controller/ChatController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ChatController.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.service.ChatService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("chat.{chatRoomId}.message")
+    public void send(Principal principal, ChatMessageDto chatMessageDto,
+        @DestinationVariable Long chatRoomId) {
+        chatService.sendMessage(chatMessageDto, Long.valueOf(principal.getName()), chatRoomId);
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ChatService.java
+++ b/src/main/java/chocoteamteam/togather/service/ChatService.java
@@ -1,0 +1,41 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.entity.ChatMessage;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.repository.ChatMessageRepository;
+import chocoteamteam.togather.repository.ChatRoomRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+    private final TopicExchange EXCHANGE;
+
+
+    public void sendMessage(ChatMessageDto chatMessageDto, Long memberId, Long chatRoomId) {
+
+        Member member = memberRepository.getReferenceById(memberId);
+        ChatRoom chatRoom = chatRoomRepository.getReferenceById(chatRoomId);
+
+        chatMessageRepository.save(ChatMessage.builder()
+            .chatRoom(chatRoom)
+            .sender(member)
+            .message(chatMessageDto.getMessage())
+            .build());
+
+        rabbitTemplate.convertAndSend(EXCHANGE.getName(), "room." + chatRoomId, chatMessageDto);
+    }
+
+
+}


### PR DESCRIPTION
**개요**

- #53 
- 팀 채팅 전송 기능 구현 

**타입** 
- [x]  feat : 새로운 기능 추가
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)

**작업 사항**
- MessageMapping을 통해 /chat/{chatRoomId}/message 로 요청이 들어오면 principal에 들어있는 회원 id를 가져와 해당 회원과 채팅방의 id로 메시지를 저장하고 메시지 브로커에서 전달합니다.
- 모든 채팅 요청 응답은 chatRoomId로 구독하고 라우팅해 채팅을 주고 받을 수 있도록 했습니다.
- chatRoomId로 구독시 동적으로 RoomId로 라우팅되는 Queue를 생성합니다.

**Test**🧪
- 로컬에서 실제 테스트를 진행했습니다.
- 같은 채팅방에 있는 회원들끼리 채팅을 주고 받을 수 있는지 테스트 진행

**Others - optional**
![image](https://user-images.githubusercontent.com/71117490/192712644-dde66150-ca62-4e5e-9107-2d4434f952ff.png)
