### PR TITLE
feat: 프로젝트 참여 신청 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.*;
+import chocoteamteam.togather.service.ProjectApplyService;
 import chocoteamteam.togather.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -12,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Tag(name = "Project", description = "프로젝트 관련 API")
 @RestController
@@ -19,6 +21,7 @@ import javax.validation.Valid;
 @RequestMapping("/projects")
 public class ProjectController {
     private final ProjectService projectService;
+	private final ProjectApplyService projectApplyService;
 
     @Operation(
             summary = "프로젝트 모집글 등록",
@@ -86,4 +89,19 @@ public class ProjectController {
     ) {
         return ResponseEntity.ok(projectService.deleteProject(projectId, member.getId(), member.getRole()));
     }
+	@Operation(
+		summary = "프로젝트 참여 신청",
+		description = "프로젝트에 참여 신청합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@PostMapping("/{projectId}/apply")
+	public ResponseEntity applyProject(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable Long projectId
+	) {
+		projectApplyService.applyProject(projectId, member.getId());
+
+		return ResponseEntity.ok().body("");
+	}
 }

--- a/src/main/java/chocoteamteam/togather/entity/Applicant.java
+++ b/src/main/java/chocoteamteam/togather/entity/Applicant.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(indexes = @Index(name = "idx_member_project",columnList = "member_id,project_id"))
 @Entity
-public class Applicant {
+public class Applicant extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/chocoteamteam/togather/entity/Applicant.java
+++ b/src/main/java/chocoteamteam/togather/entity/Applicant.java
@@ -12,6 +12,7 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Table(indexes = @Index(name = "idx_member_project",columnList = "member_id,project_id"))
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(name = "unique_member_project",
+			columnNames = {"member_id", "project_id"})
+	}
+)
 @Entity
 public class Applicant extends BaseTimeEntity {
 
@@ -30,11 +36,11 @@ public class Applicant extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn
 	private Member member;
 
-	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn
 	private Project project;
 

--- a/src/main/java/chocoteamteam/togather/entity/Applicant.java
+++ b/src/main/java/chocoteamteam/togather/entity/Applicant.java
@@ -1,0 +1,44 @@
+package chocoteamteam.togather.entity;
+
+import chocoteamteam.togather.type.ApplicantStatus;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(indexes = @Index(name = "idx_member_project",columnList = "member_id,project_id"))
+@Entity
+public class Applicant {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@JoinColumn
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY,optional = false)
+	@JoinColumn
+	private Project project;
+
+	@Enumerated(EnumType.STRING)
+	private ApplicantStatus status;
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/ApplicantException.java
+++ b/src/main/java/chocoteamteam/togather/exception/ApplicantException.java
@@ -1,0 +1,19 @@
+package chocoteamteam.togather.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicantException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final int status;
+	private final String errorMessage;
+
+	public ApplicantException(ErrorCode errorCode) {
+		super(errorCode.getErrorMessage());
+		this.errorCode = errorCode;
+		this.status = errorCode.getHttpStatus().value();
+		this.errorMessage = errorCode.getErrorMessage();
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     MAXIMUM_CHAT_ROOM(HttpStatus.BAD_REQUEST,"더이상 채팅방을 열 수 없습니다."),
     NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST,"찾을 수 없는 채팅방입니다."),
-    CHATROOM_NOT_MATCHED_PROJECT(HttpStatus.BAD_REQUEST,"프로젝트에 없는 채팅방입니다.");
+    CHATROOM_NOT_MATCHED_PROJECT(HttpStatus.BAD_REQUEST,"프로젝트에 없는 채팅방입니다."),
+    ALREADY_APPLY_PROJECT(HttpStatus.BAD_REQUEST,"이미 지원한 프로젝트입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/chocoteamteam/togather/exception/GlobalExceptionHandler.java
@@ -52,4 +52,14 @@ public class GlobalExceptionHandler {
         log.error("{} is occured", e.getErrorCode());
         return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
     }
+
+    @ExceptionHandler(ApplicantException.class)
+    public ErrorResponse applicantExceptionHandler(ApplicantException e) {
+
+        log.error("{} is occured", e.getErrorCode());
+        return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+
+
 }

--- a/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
@@ -1,0 +1,10 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+
+	boolean existsByProjectIdAndMemberId(Long projectId, Long applicantId);
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectApplyService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectApplyService.java
@@ -1,0 +1,46 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.entity.Applicant;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ApplicantException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.repository.ApplicantRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProjectApplyService {
+
+	private final ProjectRepository projectRepository;
+	private final ApplicantRepository applicantRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void applyProject(Long memberId, Long projectId) {
+		validateApplicant(projectId,memberId);
+		saveApplicant(projectId, memberId);
+	}
+
+	private void validateApplicant(Long memberId, Long projectId) {
+		if (applicantRepository.existsByProjectIdAndMemberId(projectId, memberId)) {
+			throw new ApplicantException(ErrorCode.ALREADY_APPLY_PROJECT);
+		}
+	}
+
+	private void saveApplicant(Long memberId, Long projectId) {
+		applicantRepository.save(Applicant.builder()
+			.project(projectRepository.getReferenceById(projectId))
+			.member(memberRepository.getReferenceById(memberId))
+			.status(ApplicantStatus.WAIT)
+			.build());
+	}
+
+
+
+
+}

--- a/src/main/java/chocoteamteam/togather/type/ApplicantStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/ApplicantStatus.java
@@ -1,0 +1,6 @@
+package chocoteamteam.togather.type;
+
+public enum ApplicantStatus {
+	WAIT,REJECTED,ACCEPTED,CANCEL
+
+}

--- a/src/test/java/chocoteamteam/togather/service/ProjectApplyServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectApplyServiceTest.java
@@ -1,0 +1,85 @@
+package chocoteamteam.togather.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import chocoteamteam.togather.entity.Applicant;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ApplicantException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.repository.ApplicantRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplyServiceTest {
+
+	@Mock
+	ProjectRepository projectRepository;
+
+	@Mock
+	ApplicantRepository applicantRepository;
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@InjectMocks
+	ProjectApplyService projectApplyService;
+
+	@DisplayName("프로젝트 참여 신청 성공")
+	@Test
+	void applyProject_success() {
+		//given
+		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(false);
+
+		given(projectRepository.getReferenceById(any()))
+			.willReturn(Project.builder().id(1L).build());
+
+		given(memberRepository.getReferenceById(any()))
+			.willReturn(Member.builder().id(1L).build());
+
+		ArgumentCaptor<Applicant> captor = ArgumentCaptor.forClass(Applicant.class);
+
+		//when
+		projectApplyService.applyProject(1L, 1L);
+
+		//then
+		verify(applicantRepository).save(captor.capture());
+
+		assertThat(captor.getValue().getStatus()).isEqualTo(ApplicantStatus.WAIT);
+		assertThat(captor.getValue().getProject().getId()).isEqualTo(1L);
+		assertThat(captor.getValue().getMember().getId()).isEqualTo(1L);
+	}
+
+	@DisplayName("프로젝트 참여 신청 실패 - 참여 신청 기록이 존재하는 경우")
+	@Test
+	void applyProject_fail() {
+		//given
+		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(true);
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplyService.applyProject(1L, 1L))
+			.isInstanceOf(ApplicantException.class)
+			.hasMessage(ErrorCode.ALREADY_APPLY_PROJECT.getErrorMessage());
+
+	}
+
+
+}


### PR DESCRIPTION
**개요**

- #60 
- 프로젝트 참여 신청 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- 프로젝트 참여 신청 API를 추가했습니다.
- 회원이 프로젝트에 참여 신청을 하면 신청 기록을 확인하고 없다면 신청됩니다.
- 신청 기록이 있다면 예외처리 합니다. 

**Test**🧪
- 신청이 정상적으로 이루어지는지 테스트
- 이미 신청한 프로젝트일 경우, 예외 발생 테스트

**Others**
- 회원이 자체적으로 취소하는 경우가 생길텐데, 그 부분은 DB에서 삭제하도록 구현할 예정입니다. 그렇게 해야 재신청이 가능하기 때문입니다. 더 좋은 방법이 있다면 알려주세요!
