### PR TITLE
feat: 관심 공고 조회 기능

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/InterestController.java
+++ b/src/main/java/chocoteamteam/togather/controller/InterestController.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,15 @@ public class InterestController {
         @AuthenticationPrincipal LoginMember loginMember) {
         interestService.addOrRemove(projectId, loginMember.getId());
         return ResponseEntity.ok().body("");
+    }
+
+    @Operation(
+        summary = "관심 공고 조회", description = "관심 프로젝트로 등록한 프로젝들을 조회 합니다.",
+        security = {@SecurityRequirement(name = "Authorization")}, tags = {"Interest"}
+    )
+    @GetMapping("/members/{memberId}/interests")
+    public ResponseEntity<?> getDetails(@AuthenticationPrincipal LoginMember loginMember) {
+        return ResponseEntity.ok(interestService.getDetails(loginMember.getId()));
     }
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/InterestDetail.java
+++ b/src/main/java/chocoteamteam/togather/dto/InterestDetail.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.ProjectStatus;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class InterestDetail {
+
+    private Long projectId;
+    private String title;
+    private String writer;
+    private ProjectStatus status;
+    private LocalDate deadline;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/Interest.java
+++ b/src/main/java/chocoteamteam/togather/entity/Interest.java
@@ -7,6 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +19,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Builder
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(
+            columnNames = {"member_id", "project_id"}
+        )
+})
 public class Interest extends BaseTimeEntity{
 
     @Id
@@ -24,11 +32,11 @@ public class Interest extends BaseTimeEntity{
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(unique = true)
+    @JoinColumn
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(unique = true)
+    @JoinColumn
     private Project project;
 
 }

--- a/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
+++ b/src/main/java/chocoteamteam/togather/entity/MemberTechStack.java
@@ -6,6 +6,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(
+            columnNames = {"member_id", "tech_stack_id"}
+        )
+    })
 public class MemberTechStack extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     MEMBER_STATUS_BANNED(HttpStatus.UNAUTHORIZED, "정지된 회원입니다."),
     MEMBER_STATUS_WITHDRAWAL(HttpStatus.UNAUTHORIZED, "탈퇴한 회원입니다."),
     ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "비정상적인 접근입니다."),
-
+    MAXIMUM_PROJECT_INTEREST(HttpStatus.BAD_REQUEST, "더 이상 관심 프로젝트를 추가할 수 없습니다."),
     EXIST_FALSE_GITHUB_EMAIL(HttpStatus.BAD_REQUEST,"Github의 공개된 이메일이 존재하지 않습니다."),
     MISS_MATCH_MEMBER(HttpStatus.BAD_REQUEST, "본인 정보만 수정할 수 있습니다."),
     EXIST_TRUE_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),

--- a/src/main/java/chocoteamteam/togather/repository/InterestRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/InterestRepository.java
@@ -1,11 +1,14 @@
 package chocoteamteam.togather.repository;
 
 import chocoteamteam.togather.entity.Interest;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterestRepository extends JpaRepository<Interest, Long> {
 
     Optional<Interest> findByMemberIdAndProjectId(Long memberId, Long projectId);
+
+    List<Interest> findAllByMemberId(Long memberId);
 
 }

--- a/src/main/java/chocoteamteam/togather/repository/InterestRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/InterestRepository.java
@@ -9,6 +9,8 @@ public interface InterestRepository extends JpaRepository<Interest, Long> {
 
     Optional<Interest> findByMemberIdAndProjectId(Long memberId, Long projectId);
 
+    long countByMemberId(Long memberId);
+
     List<Interest> findAllByMemberId(Long memberId);
 
 }

--- a/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/QueryDslProjectRepository.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.repository;
 
+import chocoteamteam.togather.dto.InterestDetail;
 import chocoteamteam.togather.dto.ProjectCondition;
 import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
 import chocoteamteam.togather.entity.Project;
@@ -9,6 +10,8 @@ import java.util.Optional;
 
 public interface QueryDslProjectRepository {
     List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition);
+
+    List<InterestDetail> findAllInterestProjectByIds(List<Long> projectIds);
 
     Optional<Project> findByIdWithMemberAndTechStack(Long projectId);
 }

--- a/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
@@ -64,7 +64,7 @@ public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository 
     @Override
     public List<SimpleProjectDto> findAllOptionAndSearch(ProjectCondition projectCondition) {
         List<Long> projectIds = getMultiConditionSearchId(projectCondition);
-        if (projectIds.size() == 0) {
+        if (projectIds.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QueryDslProjectRepositoryImpl.java
@@ -1,6 +1,7 @@
 package chocoteamteam.togather.repository.impl;
 
 
+import chocoteamteam.togather.dto.InterestDetail;
 import chocoteamteam.togather.dto.ProjectCondition;
 import chocoteamteam.togather.dto.queryDslSimpleDto.QSimpleMemberDto;
 import chocoteamteam.togather.dto.queryDslSimpleDto.QSimpleProjectDto;
@@ -9,6 +10,7 @@ import chocoteamteam.togather.dto.queryDslSimpleDto.SimpleProjectDto;
 import chocoteamteam.togather.entity.Project;
 import chocoteamteam.togather.repository.QueryDslProjectRepository;
 import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,25 @@ import static com.querydsl.core.group.GroupBy.list;
 @RequiredArgsConstructor
 @Repository
 public class QueryDslProjectRepositoryImpl implements QueryDslProjectRepository {
+
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<InterestDetail> findAllInterestProjectByIds(List<Long> projectIds) {
+        return new ArrayList<>(jpaQueryFactory
+            .select(Projections.fields(InterestDetail.class,
+                project.id.as("projectId"),
+                project.title.as("title"),
+                project.status.as("status"),
+                project.deadline.as("deadline"),
+                project.member.nickname.as("writer")
+            ))
+            .from(project)
+            .join(project.member)
+            .where(project.id.in(projectIds))
+            .fetch());
+
+    }
 
     @Override
     public Optional<Project> findByIdWithMemberAndTechStack(Long projectId) {

--- a/src/main/java/chocoteamteam/togather/service/InterestService.java
+++ b/src/main/java/chocoteamteam/togather/service/InterestService.java
@@ -1,5 +1,6 @@
 package chocoteamteam.togather.service;
 
+import chocoteamteam.togather.dto.InterestDetail;
 import chocoteamteam.togather.entity.Interest;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
@@ -8,7 +9,10 @@ import chocoteamteam.togather.exception.InterestException;
 import chocoteamteam.togather.repository.InterestRepository;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +53,18 @@ public class InterestService {
             .project(project)
             .build());
 
+    }
+
+    public List<InterestDetail> getDetails(Long loginMemberId) {
+
+        List<Long> projectIds = interestRepository.findAllByMemberId(loginMemberId).stream()
+            .map(e -> e.getProject().getId()).collect(Collectors.toList());
+
+        if (projectIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return projectRepository.findAllInterestProjectByIds(projectIds);
     }
 
     private void remove(Interest interest) {

--- a/src/main/java/chocoteamteam/togather/service/InterestService.java
+++ b/src/main/java/chocoteamteam/togather/service/InterestService.java
@@ -9,7 +9,7 @@ import chocoteamteam.togather.exception.InterestException;
 import chocoteamteam.togather.repository.InterestRepository;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -68,7 +68,7 @@ public class InterestService {
             .map(e -> e.getProject().getId()).collect(Collectors.toList());
 
         if (projectIds.isEmpty()) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return projectRepository.findAllInterestProjectByIds(projectIds);

--- a/src/main/java/chocoteamteam/togather/service/InterestService.java
+++ b/src/main/java/chocoteamteam/togather/service/InterestService.java
@@ -61,6 +61,7 @@ public class InterestService {
 
     }
 
+    @Transactional(readOnly = true)
     public List<InterestDetail> getDetails(Long loginMemberId) {
 
         List<Long> projectIds = interestRepository.findAllByMemberId(loginMemberId).stream()

--- a/src/main/java/chocoteamteam/togather/service/InterestService.java
+++ b/src/main/java/chocoteamteam/togather/service/InterestService.java
@@ -25,6 +25,8 @@ public class InterestService {
     private final MemberRepository memberRepository;
     private final ProjectRepository projectRepository;
 
+    private static final int MAX_INTEREST = 5;
+
     @Transactional
     public String addOrRemove(Long projectId, Long loginMemberId) {
 
@@ -34,6 +36,10 @@ public class InterestService {
         if (interestOptional.isPresent()) {
             remove(interestOptional.get());
             return "remove";
+        }
+
+        if (interestRepository.countByMemberId(loginMemberId) >= MAX_INTEREST) {
+            throw new InterestException(ErrorCode.MAXIMUM_PROJECT_INTEREST);
         }
 
         add(loginMemberId, projectId);

--- a/src/test/java/chocoteamteam/togather/service/InterestServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/InterestServiceTest.java
@@ -2,9 +2,11 @@ package chocoteamteam.togather.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
+import chocoteamteam.togather.dto.InterestDetail;
 import chocoteamteam.togather.entity.Interest;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
@@ -13,6 +15,9 @@ import chocoteamteam.togather.exception.InterestException;
 import chocoteamteam.togather.repository.InterestRepository;
 import chocoteamteam.togather.repository.MemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.ProjectStatus;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,5 +100,35 @@ class InterestServiceTest {
             .hasMessage(ErrorCode.NOT_FOUND_PROJECT.getErrorMessage());
     }
 
+    @DisplayName("관심 공고 조회 - 성공")
+    @Test
+    void getDetails_success() {
+        // given
+        LocalDate now = LocalDate.now();
+        given(interestRepository.findAllByMemberId(anyLong()))
+            .willReturn(List.of(Interest.builder()
+                .project(Project.builder()
+                    .id(1L)
+                    .build())
+                .build()));
+        given(projectRepository.findAllInterestProjectByIds(any()))
+            .willReturn(List.of(InterestDetail.builder()
+                .projectId(1L)
+                .title("title")
+                .writer("writer")
+                .status(ProjectStatus.RECRUITING)
+                .deadline(now)
+                .build()));
+
+        // when
+        List<InterestDetail> details = interestService.getDetails(1L);
+
+        // then
+        assertThat(details.get(0).getProjectId()).isEqualTo(1L);
+        assertThat(details.get(0).getTitle()).isEqualTo("title");
+        assertThat(details.get(0).getWriter()).isEqualTo("writer");
+        assertThat(details.get(0).getStatus()).isEqualTo(ProjectStatus.RECRUITING);
+        assertThat(details.get(0).getDeadline()).isEqualTo(now);
+    }
 
 }

--- a/src/test/java/chocoteamteam/togather/service/InterestServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/InterestServiceTest.java
@@ -100,6 +100,19 @@ class InterestServiceTest {
             .hasMessage(ErrorCode.NOT_FOUND_PROJECT.getErrorMessage());
     }
 
+    @DisplayName("관심 공고 추가 - 실패 관심 공고 추가 제한")
+    @Test
+    void add_failed_MAXIMUM() {
+        // given
+        given(interestRepository.countByMemberId(anyLong())).willReturn(5L);
+        // when
+
+        // then
+        assertThatThrownBy(() -> interestService.addOrRemove(1L, 1L))
+            .isInstanceOf(InterestException.class)
+            .hasMessage(ErrorCode.MAXIMUM_PROJECT_INTEREST.getErrorMessage());
+    }
+
     @DisplayName("관심 공고 조회 - 성공")
     @Test
     void getDetails_success() {


### PR DESCRIPTION
**개요**

- Closes  #56 
- 관심 공고 조회 기능

**타입** 
- [x]  feat : 새로운 기능 추가
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)

**작업 사항**
- 관심 공고를 최대 5개까지 추가할 수 있도록 추가
- 추가한 관심 공고를 전체 조회할 수 있습니다.
- memberTechStack, interest 엔티티에 유니크 제약 조건을 수정했습니다.

**Test**🧪
- 관심 공고를 5개 초과해서 추가할 수 있는지
- 관심 공고 조회 시 누락되는 값이 없는지 테스트 했습니다.
