### PR TITLE
feat: 프로젝트 신청자 조회 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
@@ -3,6 +3,8 @@ package chocoteamteam.togather.controller;
 import chocoteamteam.togather.dto.ApplicantDto;
 import chocoteamteam.togather.dto.LoginMember;
 import chocoteamteam.togather.service.ProjectApplicantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,11 @@ public class ProjectApplicantController {
 
 	private final ProjectApplicantService projectApplicantService;
 
+	@Operation(
+		summary = "프로젝트 신청자 리스트 조회 ",
+		description = "프로젝트에 신청자들을 조회합니다. WAIT 상태인 신청자만 조회됩니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project_Applicant"}
+	)
 	@PreAuthorize("hasRole('USER')")
 	@GetMapping("/{projectId}/applicants")
 	public ResponseEntity<List<ApplicantDto>> getApplicants(

--- a/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
@@ -24,6 +25,22 @@ import springfox.documentation.annotations.ApiIgnore;
 public class ProjectApplicantController {
 
 	private final ProjectApplicantService projectApplicantService;
+
+	@Operation(
+		summary = "프로젝트 참여 신청",
+		description = "프로젝트에 참여 신청합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
+	)
+	@PreAuthorize("hasRole('USER')")
+	@PostMapping("/{projectId}/applicants")
+	public ResponseEntity applyProject(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member,
+		@PathVariable Long projectId
+	) {
+		projectApplicantService.addApplicant(projectId, member.getId());
+
+		return ResponseEntity.ok().body("");
+	}
 
 	@Operation(
 		summary = "프로젝트 신청자 리스트 조회 ",
@@ -38,6 +55,7 @@ public class ProjectApplicantController {
 		return ResponseEntity.ok()
 			.body(projectApplicantService.getApplicants(projectId, member.getId()));
 	}
+
 
 
 

--- a/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
@@ -1,0 +1,38 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.service.ProjectApplicantService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Tag(name = "Project_Applicant", description = "프로젝트 신청 관리 관련 API")
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+@RestController
+public class ProjectApplicantController {
+
+	private final ProjectApplicantService projectApplicantService;
+
+	@PreAuthorize("hasRole('USER')")
+	@GetMapping("/{projectId}/applicants")
+	public ResponseEntity<List<ApplicantDto>> getApplicants(
+		@ApiIgnore @AuthenticationPrincipal LoginMember member, @PathVariable Long projectId) {
+
+		return ResponseEntity.ok()
+			.body(projectApplicantService.getApplicants(projectId, member.getId()));
+	}
+
+
+
+
+}

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -89,19 +89,5 @@ public class ProjectController {
     ) {
         return ResponseEntity.ok(projectService.deleteProject(projectId, member.getId(), member.getRole()));
     }
-	@Operation(
-		summary = "프로젝트 참여 신청",
-		description = "프로젝트에 참여 신청합니다.",
-		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project"}
-	)
-	@PreAuthorize("hasRole('USER')")
-	@PostMapping("/{projectId}/apply")
-	public ResponseEntity applyProject(
-		@ApiIgnore @AuthenticationPrincipal LoginMember member,
-		@PathVariable Long projectId
-	) {
-		projectApplicantService.addApplicant(projectId, member.getId());
 
-		return ResponseEntity.ok().body("");
-	}
 }

--- a/src/main/java/chocoteamteam/togather/controller/ProjectController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectController.java
@@ -1,7 +1,7 @@
 package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.*;
-import chocoteamteam.togather.service.ProjectApplyService;
+import chocoteamteam.togather.service.ProjectApplicantService;
 import chocoteamteam.togather.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -21,7 +21,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @RequestMapping("/projects")
 public class ProjectController {
     private final ProjectService projectService;
-	private final ProjectApplyService projectApplyService;
+	private final ProjectApplicantService projectApplicantService;
 
     @Operation(
             summary = "프로젝트 모집글 등록",
@@ -100,7 +100,7 @@ public class ProjectController {
 		@ApiIgnore @AuthenticationPrincipal LoginMember member,
 		@PathVariable Long projectId
 	) {
-		projectApplyService.applyProject(projectId, member.getId());
+		projectApplicantService.addApplicant(projectId, member.getId());
 
 		return ResponseEntity.ok().body("");
 	}

--- a/src/main/java/chocoteamteam/togather/dto/ApplicantDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ApplicantDto.java
@@ -1,0 +1,22 @@
+package chocoteamteam.togather.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ApplicantDto {
+
+	private Long applicantId;
+	private Long projectId;
+	private Long memberId;
+	private String nickname;
+	private String profileImage;
+	private List<TechStackDto> techStacks;
+
+}

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    NOT_MATCH_MEMBER_PROJECT(HttpStatus.BAD_REQUEST, "해당 게시글에 대한 권한이 없습니다"),
+    NOT_MATCH_MEMBER_PROJECT(HttpStatus.FORBIDDEN, "해당 프로젝트에 대한 권한이 없습니다"),
     NOT_FOUND_TECH_STACK(HttpStatus.BAD_REQUEST, "해당 기술 스택을 찾을 수 없습니다"),
     NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
     MEMBER_STATUS_WAIT(HttpStatus.UNAUTHORIZED, "대기중인 회원입니다."),

--- a/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
@@ -3,7 +3,7 @@ package chocoteamteam.togather.repository;
 import chocoteamteam.togather.entity.Applicant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+public interface ApplicantRepository extends JpaRepository<Applicant, Long>,QuerydslApplicantRepository  {
 
 	boolean existsByProjectIdAndMemberId(Long projectId, Long applicantId);
 

--- a/src/main/java/chocoteamteam/togather/repository/QuerydslApplicantRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/QuerydslApplicantRepository.java
@@ -1,0 +1,11 @@
+package chocoteamteam.togather.repository;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.type.ApplicantStatus;
+import java.util.List;
+
+public interface QuerydslApplicantRepository {
+
+	List<ApplicantDto> findAllByProjectId(Long projectId, ApplicantStatus status);
+
+}

--- a/src/main/java/chocoteamteam/togather/repository/impl/QuerydslApplicantRepositoryImpl.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QuerydslApplicantRepositoryImpl.java
@@ -1,0 +1,59 @@
+package chocoteamteam.togather.repository.impl;
+
+import static chocoteamteam.togather.entity.QApplicant.applicant;
+import static chocoteamteam.togather.entity.QMember.member;
+import static chocoteamteam.togather.entity.QMemberTechStack.memberTechStack;
+import static chocoteamteam.togather.entity.QTechStack.techStack;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static com.querydsl.core.types.dsl.Expressions.*;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.repository.QuerydslApplicantRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Repository
+@Transactional
+public class QuerydslApplicantRepositoryImpl implements QuerydslApplicantRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ApplicantDto> findAllByProjectId(Long projectId, ApplicantStatus status) {
+		return jpaQueryFactory.selectFrom(applicant)
+			.innerJoin(applicant.member, member)
+			.innerJoin(member.memberTechStacks, memberTechStack)
+			.innerJoin(memberTechStack.techStack, techStack)
+			.where(applicant.project.id.eq(projectId), applicant.status.eq(status))
+			.transform(groupBy(applicant.id).list(
+				Projections.fields(
+					ApplicantDto.class,
+					applicant.id.as("applicantId"),
+					asNumber(projectId).as("projectId"),
+					member.id.as("memberId"),
+					member.nickname,
+					member.profileImage,
+					list(Projections.fields(
+							TechStackDto.class,
+							techStack.id,
+							techStack.name,
+							techStack.category,
+							techStack.image
+						)
+					).as("techStacks")
+				)
+			));
+	}
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
@@ -1,0 +1,63 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.entity.Applicant;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ApplicantException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.ApplicantRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProjectApplicantService {
+
+	private final ProjectRepository projectRepository;
+	private final ApplicantRepository applicantRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void addApplicant(Long memberId, Long projectId) {
+		validateApplicant(projectId, memberId);
+		saveApplicant(projectId, memberId);
+	}
+
+	private void validateApplicant(Long memberId, Long projectId) {
+		if (applicantRepository.existsByProjectIdAndMemberId(projectId, memberId)) {
+			throw new ApplicantException(ErrorCode.ALREADY_APPLY_PROJECT);
+		}
+	}
+
+	private void saveApplicant(Long memberId, Long projectId) {
+		applicantRepository.save(Applicant.builder()
+			.project(projectRepository.getReferenceById(projectId))
+			.member(memberRepository.getReferenceById(memberId))
+			.status(ApplicantStatus.WAIT)
+			.build());
+	}
+
+	@Transactional(readOnly = true)
+	public List<ApplicantDto> getApplicants(Long projectId, Long memberId) {
+		Project project = projectRepository.findById(projectId)
+			.orElseThrow(() -> new ProjectException(ErrorCode.NOT_FOUND_PROJECT));
+
+		validateProjectOwner(memberId, project);
+
+		return applicantRepository.findAllByProjectId(projectId,
+			ApplicantStatus.WAIT);
+	}
+
+	private void validateProjectOwner(Long memberId, Project project) {
+		if (!project.getMember().getId().equals(memberId)) {
+			throw new ProjectException(ErrorCode.NOT_MATCH_MEMBER_PROJECT);
+		}
+	}
+
+}

--- a/src/test/java/chocoteamteam/togather/repository/impl/QuerydslApplicantRepositoryImplTest.java
+++ b/src/test/java/chocoteamteam/togather/repository/impl/QuerydslApplicantRepositoryImplTest.java
@@ -1,0 +1,150 @@
+package chocoteamteam.togather.repository.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.dto.TechStackDto;
+import chocoteamteam.togather.entity.Applicant;
+import chocoteamteam.togather.entity.ChatMessage;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.MemberTechStack;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.repository.ApplicantRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.MemberTechStackRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import chocoteamteam.togather.type.MemberStatus;
+import chocoteamteam.togather.type.ProviderType;
+import chocoteamteam.togather.type.Role;
+import chocoteamteam.togather.type.TechCategory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StopWatch;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import({QueryDslTestConfig.class})
+@DataJpaTest
+class QuerydslApplicantRepositoryImplTest {
+
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	ProjectRepository projectRepository;
+
+	@Autowired
+	TechStackRepository techStackRepository;
+
+	@Autowired
+	MemberTechStackRepository memberTechStackRepository;
+
+	@Autowired
+	ApplicantRepository applicantRepository;
+
+	@Autowired
+	QuerydslApplicantRepositoryImpl querydslApplicantRepository;
+
+	Member member;
+	Project project;
+
+	TechStack techStack1;
+	TechStack techStack2;
+
+	Applicant applicant;
+
+
+	@BeforeAll
+	@Transactional
+	public void beforeAll() {
+		member = memberRepository.save(
+			Member.builder()
+				.nickname("닉네임")
+				.email("이메일")
+				.profileImage("이미지")
+				.build());
+
+		project = projectRepository.save(
+			Project.builder()
+				.member(member)
+				.build());
+
+		techStack1 = techStackRepository.save(
+			TechStack.builder()
+				.name("자바")
+				.category(TechCategory.BACKEND)
+				.image("자바 이미지")
+				.build()
+		);
+		techStack2 = techStackRepository.save(
+			TechStack.builder()
+				.name("리액트")
+				.category(TechCategory.FRONTEND)
+				.image("리액트 이미지")
+				.build()
+		);
+
+		for (int i = 0; i < 10000; i++) {
+			// 회원 저장
+			Member tempMember = memberRepository.save(
+				Member.builder()
+					.nickname("test" + i)
+					.email("email"+i)
+					.profileImage("image")
+					.build());
+
+			// 회원 테크 스택 저장
+			memberTechStackRepository.save(
+				MemberTechStack.builder()
+					.techStack(techStack1)
+					.member(tempMember)
+					.build()
+			);
+
+			memberTechStackRepository.save(
+				MemberTechStack.builder()
+					.techStack(techStack2)
+					.member(tempMember)
+					.build()
+			);
+
+			applicant = applicantRepository.save(
+				Applicant.builder()
+					.project(project)
+					.member(tempMember)
+					.status(ApplicantStatus.WAIT)
+					.build()
+			);
+		}
+	}
+
+	@DisplayName("ApplicantDto , 10000건 조회 ")
+	@Test
+	void findAllByProjectId() {
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		List<ApplicantDto> result = querydslApplicantRepository.findAllByProjectId(1L,
+			ApplicantStatus.WAIT);
+
+		stopWatch.stop();
+		System.out.println("시간 = "+ stopWatch.getTotalTimeMillis());
+
+		assertThat(result.size()).isEqualTo(10000);
+	}
+}

--- a/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
@@ -1,0 +1,134 @@
+package chocoteamteam.togather.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.entity.Applicant;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.exception.ApplicantException;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.ProjectException;
+import chocoteamteam.togather.repository.ApplicantRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.type.ApplicantStatus;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicantServiceTest {
+
+	@Mock
+	ProjectRepository projectRepository;
+
+	@Mock
+	ApplicantRepository applicantRepository;
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@InjectMocks
+	ProjectApplicantService projectApplicantService;
+
+	@DisplayName("프로젝트 참여 신청 성공")
+	@Test
+	void addApplcant_success() {
+		//given
+		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(false);
+
+		given(projectRepository.getReferenceById(any()))
+			.willReturn(Project.builder().id(1L).build());
+
+		given(memberRepository.getReferenceById(any()))
+			.willReturn(Member.builder().id(1L).build());
+
+		ArgumentCaptor<Applicant> captor = ArgumentCaptor.forClass(Applicant.class);
+
+		//when
+		projectApplicantService.addApplicant(1L, 1L);
+
+		//then
+		verify(applicantRepository).save(captor.capture());
+
+		assertThat(captor.getValue().getStatus()).isEqualTo(ApplicantStatus.WAIT);
+		assertThat(captor.getValue().getProject().getId()).isEqualTo(1L);
+		assertThat(captor.getValue().getMember().getId()).isEqualTo(1L);
+	}
+
+	@DisplayName("프로젝트 참여 신청 실패 - 참여 신청 기록이 존재하는 경우")
+	@Test
+	void addApplicant_fail() {
+		//given
+		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(true);
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.addApplicant(1L, 1L))
+			.isInstanceOf(ApplicantException.class)
+			.hasMessage(ErrorCode.ALREADY_APPLY_PROJECT.getErrorMessage());
+
+	}
+
+	@DisplayName("프로젝트 신청자 목록 조회 성공")
+	@Test
+	void getApplicants_success(){
+	    //given
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(Project.builder()
+					.member(Member.builder()
+						.id(1L)
+						.build())
+				.build()));
+
+		given(applicantRepository.findAllByProjectId(anyLong(),any()))
+			.willReturn(Arrays.asList(ApplicantDto.builder()
+				.applicantId(1L)
+				.memberId(1L)
+				.build()
+			));
+
+	    //when
+		List<ApplicantDto> applicants = projectApplicantService.getApplicants(1L, 1L);
+
+		//then
+		assertThat(applicants.get(0).getApplicantId()).isEqualTo(1L);
+	}
+
+	@DisplayName("프로젝트 신청자 목록 조회 실패 - 프로젝트 관리자가 아닌 경우")
+	@Test
+	void getApplicants_fail_notMatchMemberProject(){
+	    //given
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(Project.builder()
+					.member(Member.builder()
+						.id(1L)
+						.build())
+				.build()));
+
+	    //when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.getApplicants(1L, 2L))
+			.isInstanceOf(ProjectException.class)
+			.hasMessage(ErrorCode.NOT_MATCH_MEMBER_PROJECT.getErrorMessage());
+	}
+
+
+
+
+}


### PR DESCRIPTION
**개요**

- #60 
- 프로젝트 신청자 조회 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가

**작업 사항**
- 프로젝트 id로 신청자를 확인할 수 있는 API를 추가했습니다.
- 프로젝트 관리자(공고 작성자)만 확인할 수 있으며, WAIT 상태의 신청자만 조회됩니다.

**Test**🧪
- Querydsl 잘 작동하는지 test - 10000건 조회
- 요청한 회원이 프로젝트 관리자인지 검증 테스트
