### PR TITLE
feat: 팀 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation group: 'org.webjars', name: 'sockjs-client', version: '1.1.2'
+    implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/chocoteamteam/togather/component/stomp/ChatErrorHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/stomp/ChatErrorHandler.java
@@ -1,0 +1,59 @@
+package chocoteamteam.togather.component.stomp;
+
+import chocoteamteam.togather.dto.ErrorResponse;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.TokenException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChatErrorHandler extends StompSubProtocolErrorHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage,
+		Throwable ex) {
+
+		if (ex.getCause() instanceof TokenException) {
+			TokenException exception = (TokenException) ex.getCause();
+
+			return prepareErrorMessage(exception.getErrorCode());
+
+		}
+
+		return super.handleClientMessageProcessingError(clientMessage, ex);
+	}
+
+	private Message<byte[]> prepareErrorMessage(ErrorCode errorCode) {
+
+		ErrorResponse response = ErrorResponse.builder()
+			.errorMessage(errorCode.getErrorMessage())
+			.errorCode(errorCode)
+			.status(errorCode.getHttpStatus().value())
+			.build();
+
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+
+		accessor.setMessage(errorCode.name());
+		accessor.setLeaveMutable(true);
+
+		try {
+			return MessageBuilder.createMessage(objectMapper.writeValueAsString(response).getBytes(),
+				accessor.getMessageHeaders());
+		} catch (JsonProcessingException e) {
+			return MessageBuilder.createMessage(errorCode.name().getBytes(),
+				accessor.getMessageHeaders());
+		}
+	}
+}

--- a/src/main/java/chocoteamteam/togather/component/stomp/StompJwtHandler.java
+++ b/src/main/java/chocoteamteam/togather/component/stomp/StompJwtHandler.java
@@ -1,0 +1,49 @@
+package chocoteamteam.togather.component.stomp;
+
+import chocoteamteam.togather.dto.TokenMemberInfo;
+import chocoteamteam.togather.exception.ErrorCode;
+import chocoteamteam.togather.exception.TokenException;
+import chocoteamteam.togather.service.JwtService;
+import com.sun.security.auth.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@Component
+public class StompJwtHandler implements ChannelInterceptor {
+
+	private final JwtService jwtService;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message,
+			StompHeaderAccessor.class);
+
+		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+			try {
+				TokenMemberInfo info = jwtService.parseAccessToken(
+					accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION).substring(7));
+
+				log.info("Member connected WebSocket. id : {} , name : {}",info.getId(),info.getNickname());
+
+				accessor.setUser(new UserPrincipal(String.valueOf(info.getId())));
+			} catch (Exception e) {
+				throw new TokenException(ErrorCode.INVALID_TOKEN,e);
+			}
+		}
+
+		return message;
+	}
+}

--- a/src/main/java/chocoteamteam/togather/config/RabbitConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/RabbitConfig.java
@@ -1,0 +1,60 @@
+package chocoteamteam.togather.config;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableRabbit
+public class RabbitConfig {
+
+    private static final String CHAT_QUEUE_NAME = "chat.queue";
+
+    @Bean
+    public RabbitTemplate rabbitTemplate() {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory());
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        rabbitTemplate.setRoutingKey(CHAT_QUEUE_NAME);
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public SimpleMessageListenerContainer container() {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory());
+        container.setQueueNames(CHAT_QUEUE_NAME);
+        return container;
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory factory = new CachingConnectionFactory();
+        factory.setHost("localhost");
+        factory.setUsername("root");
+        factory.setPassword("root");
+        return factory;
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jsonMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        objectMapper.registerModule(dateTimeModule());
+
+        return new Jackson2JsonMessageConverter(objectMapper);
+    }
+
+    @Bean
+    public Module dateTimeModule() {
+        return new JavaTimeModule();
+    }
+}

--- a/src/main/java/chocoteamteam/togather/config/RabbitConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/RabbitConfig.java
@@ -56,8 +56,8 @@ public class RabbitConfig {
     public ConnectionFactory connectionFactory() {
         CachingConnectionFactory factory = new CachingConnectionFactory();
         factory.setHost("localhost");
-        factory.setUsername("root");
-        factory.setPassword("root");
+        factory.setUsername("admin");
+        factory.setPassword("admin");
         return factory;
     }
 

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -18,10 +18,11 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompJwtHandler stompJwtHandler;
     private final ChatErrorHandler chatErrorHandler;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/stomp/chat")
-            .setAllowedOrigins("http://*.*.*.*:8080")
+            .setAllowedOriginPatterns("*")
             .withSockJS();
         registry.setErrorHandler(chatErrorHandler);
     }
@@ -30,7 +31,14 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setPathMatcher(new AntPathMatcher("."));
         registry.setApplicationDestinationPrefixes("/app");
-        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
+            .setRelayHost("localhost")
+            .setRelayPort(61613)
+            .setClientLogin("admin")
+            .setClientPasscode("admin")
+            .setSystemLogin("admin")
+            .setSystemPasscode("admin");
+
     }
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -16,6 +16,7 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/stomp/chat")
             .setAllowedOrigins("http://*.*.*.*:8080")
             .withSockJS();
+        registry.setErrorHandler(chatErrorHandler);
     }
 
     @Override
@@ -23,5 +24,9 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
         registry.setPathMatcher(new AntPathMatcher("."));
         registry.setApplicationDestinationPrefixes("/app");
         registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompJwtHandler);
     }
 }

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -7,10 +7,13 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSocketMessageBroker
 public class StompConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompJwtHandler stompJwtHandler;
+    private final ChatErrorHandler chatErrorHandler;
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/stomp/chat")

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -1,6 +1,10 @@
 package chocoteamteam.togather.config;
 
+import chocoteamteam.togather.component.stomp.ChatErrorHandler;
+import chocoteamteam.togather.component.stomp.StompJwtHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;

--- a/src/main/java/chocoteamteam/togather/config/StompConfig.java
+++ b/src/main/java/chocoteamteam/togather/config/StompConfig.java
@@ -1,0 +1,27 @@
+package chocoteamteam.togather.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class StompConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/stomp/chat")
+            .setAllowedOrigins("http://*.*.*.*:8080")
+            .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setPathMatcher(new AntPathMatcher("."));
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+    }
+}

--- a/src/main/java/chocoteamteam/togather/controller/ChatController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ChatController.java
@@ -1,0 +1,23 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.service.ChatService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("chat.{chatRoomId}.message")
+    public void send(Principal principal, ChatMessageDto chatMessageDto,
+        @DestinationVariable Long chatRoomId) {
+        chatService.sendMessage(chatMessageDto, Long.valueOf(principal.getName()), chatRoomId);
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/service/ChatService.java
+++ b/src/main/java/chocoteamteam/togather/service/ChatService.java
@@ -1,0 +1,41 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.dto.ChatMessageDto;
+import chocoteamteam.togather.entity.ChatMessage;
+import chocoteamteam.togather.entity.ChatRoom;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.repository.ChatMessageRepository;
+import chocoteamteam.togather.repository.ChatRoomRepository;
+import chocoteamteam.togather.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+    private final TopicExchange EXCHANGE;
+
+
+    public void sendMessage(ChatMessageDto chatMessageDto, Long memberId, Long chatRoomId) {
+
+        Member member = memberRepository.getReferenceById(memberId);
+        ChatRoom chatRoom = chatRoomRepository.getReferenceById(chatRoomId);
+
+        chatMessageRepository.save(ChatMessage.builder()
+            .chatRoom(chatRoom)
+            .sender(member)
+            .message(chatMessageDto.getMessage())
+            .build());
+
+        rabbitTemplate.convertAndSend(EXCHANGE.getName(), "room." + chatRoomId, chatMessageDto);
+    }
+
+
+}


### PR DESCRIPTION
**개요**

- #53 
- WebSocket + STOMP + RabbitMQ를 이용해 팀 채팅 기능을 구현했습니다.


**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 웹소켓 최초 연결 시 header의 엑세스 토큰을 넘겨 받아 연결에 성공했을 경우 엑세스 토큰을 검증하고 Principal.name에 Id를 저장합니다.
- topic Exchange 사용해 room.{chatRoomId}로 라우팅 했으며 회원마다 topic Exchange와 room.{chatRoomId}으로 바인딩 된 큐를 생성해 구독할 수 있도록 했습니다.
- 회원이 채팅 전송 시 Principal.name에 저장돼있는 회원의 아이디를 가져와 채팅방 ID, 시간, 메시지 내용을 저장합니다.


**Test**🧪
- 소켓 연결 시 넘어온 엑세스토큰을 잘 검증하는지 #54 
- 같은 채팅방에 있는 회원들끼리 채팅을 주고 받을 수 있는지 #55 
