### PR TITLE
feat: 주간 기술스택 통계 api 및 통계작업

### DIFF
--- a/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
@@ -71,7 +71,7 @@ public class TechStackStatisticsConfig {
                 .from(projectTechStack)
                 .innerJoin(projectTechStack.project, project)
                 .innerJoin(projectTechStack.techStack, techStack)
-                .where(project.createdAt.between(jobParam.getStartDate(), jobParam.getEndDate().plusDays(7))) // test 수정
+                .where(project.createdAt.between(jobParam.getStartDate(), jobParam.getEndDate()))
                 .groupBy(techStack.id)
         );
     }

--- a/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
@@ -52,7 +52,7 @@ public class TechStackStatisticsConfig {
     public Step techStackStatisticsStep() {
         return stepBuilderFactory
                 .get("techStackStatisticsStep")
-                .<TechStatisticsDto, WeeklyTechStatistics>chunk(10)
+                .<TechStatisticsDto, WeeklyTechStatistics>chunk(CHUNK_SIZE)
                 .reader(techStackStatisticsReader())
                 .processor(techStackStatisticsProcessor())
                 .writer(techStackStatisticsWriter())

--- a/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfig.java
@@ -1,0 +1,99 @@
+package chocoteamteam.togather.batch.application.job;
+
+
+import chocoteamteam.togather.batch.application.job.model.TechStatisticsDto;
+import chocoteamteam.togather.batch.application.job.param.TechStatisticsJobParam;
+import chocoteamteam.togather.batch.domain.entity.WeeklyTechStatistics;
+import com.querydsl.core.types.Projections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.batch.item.querydsl.reader.QuerydslPagingItemReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+
+import static chocoteamteam.togather.entity.QProject.project;
+import static chocoteamteam.togather.entity.QProjectTechStack.projectTechStack;
+import static chocoteamteam.togather.entity.QTechStack.techStack;
+
+@RequiredArgsConstructor
+@Configuration
+public class TechStackStatisticsConfig {
+    private static final int CHUNK_SIZE = 10;
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final TechStatisticsJobParam jobParam;
+    private final EntityManagerFactory emf;
+
+    @Bean
+    @Qualifier("techStackStatisticsJob")
+    public Job techStackStatisticsJob(JobExecutionListener jobExecutionListener) {
+        return jobBuilderFactory.get("techStackStatisticsJob")
+                .incrementer(new RunIdIncrementer())
+                .start(techStackStatisticsStep())
+                .listener(jobExecutionListener)
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step techStackStatisticsStep() {
+        return stepBuilderFactory
+                .get("techStackStatisticsStep")
+                .<TechStatisticsDto, WeeklyTechStatistics>chunk(10)
+                .reader(techStackStatisticsReader())
+                .processor(techStackStatisticsProcessor())
+                .writer(techStackStatisticsWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public QuerydslPagingItemReader<TechStatisticsDto> techStackStatisticsReader() {
+        return new QuerydslPagingItemReader<>(emf, CHUNK_SIZE, queryFactory -> queryFactory
+                .select(Projections.constructor(TechStatisticsDto.class,
+                        techStack.id,
+                        techStack.name,
+                        techStack.category,
+                        techStack.id.count()))
+                .from(projectTechStack)
+                .innerJoin(projectTechStack.project, project)
+                .innerJoin(projectTechStack.techStack, techStack)
+                .where(project.createdAt.between(jobParam.getStartDate(), jobParam.getEndDate().plusDays(7))) // test 수정
+                .groupBy(techStack.id)
+        );
+    }
+
+    @Bean
+    @StepScope
+    public ItemProcessor<TechStatisticsDto, WeeklyTechStatistics> techStackStatisticsProcessor() {
+        return (techStatisticsDto) -> WeeklyTechStatistics.builder()
+                .techStackId(techStatisticsDto.getTechStackId())
+                .techStackName(techStatisticsDto.getTechStackName())
+                .techStackCategory(techStatisticsDto.getTechStackCategory())
+                .count(techStatisticsDto.getCount())
+                .weeks(jobParam.getWeeks())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaItemWriter<WeeklyTechStatistics> techStackStatisticsWriter() {
+        return new JpaItemWriterBuilder<WeeklyTechStatistics>()
+                .entityManagerFactory(emf)
+                .build();
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/batch/application/job/model/TechStatisticsDto.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/model/TechStatisticsDto.java
@@ -1,0 +1,16 @@
+package chocoteamteam.togather.batch.application.job.model;
+
+import chocoteamteam.togather.type.TechCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TechStatisticsDto {
+    private Long techStackId;
+    private String techStackName;
+    private TechCategory techStackCategory;
+    private Long count;
+}

--- a/src/main/java/chocoteamteam/togather/batch/application/job/model/TechStatisticsDto.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/model/TechStatisticsDto.java
@@ -2,11 +2,13 @@ package chocoteamteam.togather.batch.application.job.model;
 
 import chocoteamteam.togather.type.TechCategory;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 public class TechStatisticsDto {
     private Long techStackId;

--- a/src/main/java/chocoteamteam/togather/batch/application/job/param/TechStatisticsJobParam.java
+++ b/src/main/java/chocoteamteam/togather/batch/application/job/param/TechStatisticsJobParam.java
@@ -1,0 +1,34 @@
+package chocoteamteam.togather.batch.application.job.param;
+
+import lombok.Getter;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@JobScope
+@Component
+public class TechStatisticsJobParam {
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Integer weeks;
+
+    @Value("#{jobParameters[startDate]}")
+    private void setStartDate(String startDate) {
+        this.startDate = LocalDateTime.parse(startDate);
+    }
+
+    @Value("#{jobParameters[endDate]}")
+    private void setEndDate(String endDate) {
+        this.endDate = LocalDateTime.parse(endDate);
+    }
+
+    @Value("#{jobParameters[weeks]}")
+    private void setWeeks(Integer weeks) {
+        this.weeks = weeks;
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/batch/domain/entity/WeeklyTechStatistics.java
+++ b/src/main/java/chocoteamteam/togather/batch/domain/entity/WeeklyTechStatistics.java
@@ -1,0 +1,26 @@
+package chocoteamteam.togather.batch.domain.entity;
+
+import chocoteamteam.togather.type.TechCategory;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class WeeklyTechStatistics {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long techStackId;
+    private String techStackName;
+
+    @Enumerated(EnumType.STRING)
+    private TechCategory techStackCategory;
+
+    private Long count;
+    private Integer weeks;
+}

--- a/src/main/java/chocoteamteam/togather/batch/domain/repository/WeeklyTechStatisticsRepository.java
+++ b/src/main/java/chocoteamteam/togather/batch/domain/repository/WeeklyTechStatisticsRepository.java
@@ -1,0 +1,7 @@
+package chocoteamteam.togather.batch.domain.repository;
+
+import chocoteamteam.togather.batch.domain.entity.WeeklyTechStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyTechStatisticsRepository extends JpaRepository<WeeklyTechStatistics, Long> {
+}

--- a/src/main/java/chocoteamteam/togather/batch/domain/repository/WeeklyTechStatisticsRepository.java
+++ b/src/main/java/chocoteamteam/togather/batch/domain/repository/WeeklyTechStatisticsRepository.java
@@ -3,5 +3,8 @@ package chocoteamteam.togather.batch.domain.repository;
 import chocoteamteam.togather.batch.domain.entity.WeeklyTechStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WeeklyTechStatisticsRepository extends JpaRepository<WeeklyTechStatistics, Long> {
+    List<WeeklyTechStatistics> findAllByWeeks(Integer weeks);
 }

--- a/src/main/java/chocoteamteam/togather/batch/schduler/ProjectStatusJobScheduler.java
+++ b/src/main/java/chocoteamteam/togather/batch/schduler/ProjectStatusJobScheduler.java
@@ -1,10 +1,8 @@
 package chocoteamteam.togather.batch.schduler;
 
-import chocoteamteam.togather.batch.application.job.ProjectStatusJobConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -15,7 +13,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,8 +23,6 @@ public class ProjectStatusJobScheduler {
 
     @Scheduled(cron = "0 5 0 * * *")
     public void runJob() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
-        log.info("ProjectStatusJobScheduler start!");
-
         jobLauncher.run(changeProjectStatusJob, new JobParametersBuilder()
                 .addString("nowDate", LocalDate.now().toString())
                 .toJobParameters());

--- a/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
+++ b/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
@@ -1,0 +1,38 @@
+package chocoteamteam.togather.batch.schduler;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.WeekFields;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class techStackStatisticsJobScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job techStackStatisticsJob;
+
+    // 월 실행, 지난 주 월 ~ 일 통계
+    @Scheduled(cron = "0 30 0 ? * MON")
+    public void runJob() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+        LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        jobLauncher.run(techStackStatisticsJob, new JobParametersBuilder()
+                .addString("startDate", now.minusDays(7).toString())
+                .addString("endDate", now.minusDays(1).toString())
+                .addLong("weeks", (long) (now.get(WeekFields.ISO.weekOfYear()) - 1))
+                .toJobParameters());
+    }
+}

--- a/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
+++ b/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
@@ -28,11 +28,12 @@ public class techStackStatisticsJobScheduler {
     // 월 실행, 지난 주 월 ~ 일 통계
     @Scheduled(cron = "0 30 0 ? * MON")
     public void runJob() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
-        LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        LocalDate now = LocalDate.now();
         jobLauncher.run(techStackStatisticsJob, new JobParametersBuilder()
-                .addString("startDate", now.minusDays(7).toString())
-                .addString("endDate", now.toString())
+                .addString("startDate", LocalDateTime.of(now.minusDays(7), LocalTime.MIN).toString())
+                .addString("endDate", LocalDateTime.of(now.minusDays(1), LocalTime.MAX).toString())
                 .addLong("weeks", (long) (now.get(WeekFields.ISO.weekOfYear()) - 1))
                 .toJobParameters());
+
     }
 }

--- a/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
+++ b/src/main/java/chocoteamteam/togather/batch/schduler/techStackStatisticsJobScheduler.java
@@ -31,7 +31,7 @@ public class techStackStatisticsJobScheduler {
         LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
         jobLauncher.run(techStackStatisticsJob, new JobParametersBuilder()
                 .addString("startDate", now.minusDays(7).toString())
-                .addString("endDate", now.minusDays(1).toString())
+                .addString("endDate", now.toString())
                 .addLong("weeks", (long) (now.get(WeekFields.ISO.weekOfYear()) - 1))
                 .toJobParameters());
     }

--- a/src/main/java/chocoteamteam/togather/controller/StatisticsController.java
+++ b/src/main/java/chocoteamteam/togather/controller/StatisticsController.java
@@ -1,0 +1,36 @@
+package chocoteamteam.togather.controller;
+
+import chocoteamteam.togather.dto.WeeklyTechStackStatisticsResponse;
+import chocoteamteam.togather.service.TechStackStatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/techStackStatistics")
+public class StatisticsController {
+
+    private final TechStackStatisticsService techStackStatisticsService;
+
+    @Operation(summary = "주간 기술스택 통계 조회 api",
+            description = "통계자료를 반환합니다.",
+            tags = {"TechStack Statistics"})
+    @GetMapping
+    public ResponseEntity<WeeklyTechStackStatisticsResponse> getWeeklyTechStackStatistics() {
+        return ResponseEntity.ok(techStackStatisticsService.getWeeklyStatistics());
+    }
+
+    @Operation(summary = "특정 주차 기술스택 통계 조회 api",
+            description = "특정 주차의 통계자료를 반환합니다.",
+            tags = {"TechStack Statistics"})
+    @GetMapping("/{weeks}")
+    public ResponseEntity<WeeklyTechStackStatisticsResponse> getTechStackStatisticsByWeeks(@PathVariable Integer weeks) {
+        return ResponseEntity.ok(techStackStatisticsService.getWeeklyStatistics(weeks));
+    }
+
+}

--- a/src/main/java/chocoteamteam/togather/controller/StatisticsController.java
+++ b/src/main/java/chocoteamteam/togather/controller/StatisticsController.java
@@ -3,6 +3,7 @@ package chocoteamteam.togather.controller;
 import chocoteamteam.togather.dto.WeeklyTechStackStatisticsResponse;
 import chocoteamteam.togather.service.TechStackStatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "TechStack Statistics", description = "주단위 기술스택 통계 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/techStackStatistics")
@@ -27,7 +29,7 @@ public class StatisticsController {
 
     @Operation(summary = "특정 주차 기술스택 통계 조회 api",
             description = "특정 주차의 통계자료를 반환합니다.",
-            tags = {"TechStack Statistics"})
+            tags = {"TechStack Statistics by weeks"})
     @GetMapping("/{weeks}")
     public ResponseEntity<WeeklyTechStackStatisticsResponse> getTechStackStatisticsByWeeks(@PathVariable Integer weeks) {
         return ResponseEntity.ok(techStackStatisticsService.getWeeklyStatistics(weeks));

--- a/src/main/java/chocoteamteam/togather/dto/WeeklyTechStackStatisticsResponse.java
+++ b/src/main/java/chocoteamteam/togather/dto/WeeklyTechStackStatisticsResponse.java
@@ -1,0 +1,36 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.batch.application.job.model.TechStatisticsDto;
+import chocoteamteam.togather.batch.domain.entity.WeeklyTechStatistics;
+import chocoteamteam.togather.type.TechCategory;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class WeeklyTechStackStatisticsResponse {
+    private Integer weeks;
+
+    private final List<TechStatisticsDto> techStatistics = new ArrayList<>();
+
+    public WeeklyTechStackStatisticsResponse fromEntity(List<WeeklyTechStatistics> weeklyTechStatistics, Integer weeks) {
+        this.weeks = weeks;
+
+        for (WeeklyTechStatistics weeklyTechStatistic : weeklyTechStatistics) {
+            techStatistics.add(TechStatisticsDto.builder()
+                    .techStackId(weeklyTechStatistic.getTechStackId())
+                    .techStackName(weeklyTechStatistic.getTechStackName())
+                    .techStackCategory(weeklyTechStatistic.getTechStackCategory())
+                    .count(weeklyTechStatistic.getCount())
+                    .build());
+        }
+
+        return this;
+    }
+}

--- a/src/main/java/chocoteamteam/togather/service/TechStackStatisticsService.java
+++ b/src/main/java/chocoteamteam/togather/service/TechStackStatisticsService.java
@@ -1,0 +1,24 @@
+package chocoteamteam.togather.service;
+
+import chocoteamteam.togather.batch.domain.repository.WeeklyTechStatisticsRepository;
+import chocoteamteam.togather.dto.WeeklyTechStackStatisticsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+
+@RequiredArgsConstructor
+@Service
+public class TechStackStatisticsService {
+    private final WeeklyTechStatisticsRepository weeklyTechStatisticsRepository;
+
+    public WeeklyTechStackStatisticsResponse getWeeklyStatistics() {
+        int weeks = LocalDate.now().minusDays(7).get(WeekFields.ISO.weekOfYear());
+        return new WeeklyTechStackStatisticsResponse().fromEntity(weeklyTechStatisticsRepository.findAllByWeeks(weeks), weeks);
+    }
+
+    public WeeklyTechStackStatisticsResponse getWeeklyStatistics(int weeks) {
+        return new WeeklyTechStackStatisticsResponse().fromEntity(weeklyTechStatisticsRepository.findAllByWeeks(weeks), weeks);
+    }
+}

--- a/src/test/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfigTest.java
+++ b/src/test/java/chocoteamteam/togather/batch/application/job/TechStackStatisticsConfigTest.java
@@ -1,0 +1,105 @@
+package chocoteamteam.togather.batch.application.job;
+
+import chocoteamteam.togather.batch.BatchTestConfig;
+import chocoteamteam.togather.batch.application.job.listener.JobExecutionLogger;
+import chocoteamteam.togather.batch.application.job.param.TechStatisticsJobParam;
+import chocoteamteam.togather.batch.domain.entity.WeeklyTechStatistics;
+import chocoteamteam.togather.batch.domain.repository.WeeklyTechStatisticsRepository;
+import chocoteamteam.togather.entity.Member;
+import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.ProjectTechStack;
+import chocoteamteam.togather.entity.TechStack;
+import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectRepository;
+import chocoteamteam.togather.repository.ProjectTechStackRepository;
+import chocoteamteam.togather.repository.TechStackRepository;
+import chocoteamteam.togather.repository.impl.QueryDslTestConfig;
+import chocoteamteam.togather.type.TechCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.WeekFields;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBatchTest
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TechStackStatisticsConfig.class, BatchTestConfig.class, QueryDslTestConfig.class,
+        JobExecutionLogger.class, TechStatisticsJobParam.class})
+class TechStackStatisticsConfigTest {
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TechStackRepository techStackRepository;
+    @Autowired
+    private ProjectTechStackRepository projectTechStackRepository;
+    @Autowired
+    private WeeklyTechStatisticsRepository weeklyTechStatisticsRepository;
+
+    @BeforeEach
+    void setUp() {
+        Member member = memberRepository.save(Member.builder()
+                .email("togather@to.com")
+                .nickname("두개더")
+                .profileImage("img_url")
+                .build());
+        Project project = projectRepository.save(Project.builder()
+                .member(member)
+                .build());
+        Project project2 = projectRepository.save(Project.builder()
+                .member(member)
+                .build());
+        TechStack techStack1 = techStackRepository.save(TechStack.builder()
+                .name("tech1")
+                .category(TechCategory.BACKEND)
+                .build());
+        TechStack techStack2 = techStackRepository.save(TechStack.builder()
+                .name("tech2")
+                .category(TechCategory.FRONTEND)
+                .build());
+
+        projectTechStackRepository.save(new ProjectTechStack(project, techStack1));
+        projectTechStackRepository.save(new ProjectTechStack(project2, techStack1));
+        projectTechStackRepository.save(new ProjectTechStack(project2, techStack2));
+    }
+
+    @Test
+    @DisplayName("기술스택 주간 통계")
+    void techStackStatisticsConfig_Test() throws Exception {
+        //given
+        //when
+        LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(new JobParametersBuilder()
+                .addString("startDate", now.minusDays(7).toString())
+                .addString("endDate", now.plusDays(1).toString()) // Add a day to test
+                .addLong("weeks", (long) (now.get(WeekFields.ISO.weekOfYear()) - 1))
+                .toJobParameters());
+
+        //then
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+
+        List<WeeklyTechStatistics> all = weeklyTechStatisticsRepository.findAll();
+        assertEquals(2, all.size());
+    }
+}


### PR DESCRIPTION
**개요**

- #62 
- 주간 기술스택 통계 배치 작업 
- 통계자료 조회 api

**타입** 

- [x]  feat : 새로운 기능 추가

**작업 사항**
- 주간에 사용된 프로젝트의 기술스택을 통계 집계하는 배치작업입니다.
- 최근 주차 기술스택 통계 조회 api
- 특정 주차 기술스택 통계 조회 api
- 
**Test**🧪

- 배치테스트를 하였습니다.
- api는 로직이 거의 없어 단위테스트는 하지 않았고 로컬에서 테스트 자료를 올렸습니다.

**Others - optional**
- 실제 로컬에서 Job 테스트도 했습니다.
![통계](https://user-images.githubusercontent.com/49369306/193420583-6851c5c8-d7f6-467c-940b-f266ebabffe5.PNG)

- api테스트
![apitest](https://user-images.githubusercontent.com/49369306/193422976-9c661269-e3b1-42a4-ba2c-e8515cf4f8e2.PNG)

