### PR TITLE
feat: 신청 수락,거절 API 및 신청 삭제 API 추가

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
@@ -61,6 +61,12 @@ public class ProjectApplicantController {
 			.body(projectApplicantService.getApplicants(projectId, member.getId()));
 	}
 
+
+	@Operation(
+		summary = "프로젝트 신청자 수락",
+		description = "프로젝트 신청자의 신청을 수락합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project_Applicant"}
+	)
 	@PreAuthorize("hasRole('USER')")
 	@PutMapping("/{projectId}/applicants/{memberId}/accept")
 	public ResponseEntity acceptApplicant(
@@ -77,6 +83,12 @@ public class ProjectApplicantController {
 		return ResponseEntity.ok().body("");
 	}
 
+
+	@Operation(
+		summary = "프로젝트 신청자 거절",
+		description = "프로젝트에 신청자의 신청을 거절합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project_Applicant"}
+	)
 	@PreAuthorize("hasRole('USER')")
 	@PutMapping("/{projectId}/applicants/{memberId}/reject")
 	public ResponseEntity rejectApplicant(
@@ -93,6 +105,12 @@ public class ProjectApplicantController {
 		return ResponseEntity.ok().body("");
 	}
 
+
+	@Operation(
+		summary = "프로젝트 신청자 취소",
+		description = "프로젝트에 신청자를 삭제합니다.",
+		security = {@SecurityRequirement(name = "Authorization")}, tags = {"Project_Applicant"}
+	)
 	@PreAuthorize("hasRole('USER') and principal.id == #memberId or hasRole('ADMIN')")
 	@DeleteMapping("/{projectId}/applicants/{memberId}")
 	public ResponseEntity deleteApplicant(

--- a/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
+++ b/src/main/java/chocoteamteam/togather/controller/ProjectApplicantController.java
@@ -2,7 +2,9 @@ package chocoteamteam.togather.controller;
 
 import chocoteamteam.togather.dto.ApplicantDto;
 import chocoteamteam.togather.dto.LoginMember;
+import chocoteamteam.togather.dto.ManageApplicantForm;
 import chocoteamteam.togather.service.ProjectApplicantService;
+import chocoteamteam.togather.type.ApplicantStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,9 +13,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
@@ -37,7 +42,7 @@ public class ProjectApplicantController {
 		@ApiIgnore @AuthenticationPrincipal LoginMember member,
 		@PathVariable Long projectId
 	) {
-		projectApplicantService.addApplicant(projectId, member.getId());
+		projectApplicantService.applyForProject(projectId, member.getId());
 
 		return ResponseEntity.ok().body("");
 	}
@@ -56,8 +61,46 @@ public class ProjectApplicantController {
 			.body(projectApplicantService.getApplicants(projectId, member.getId()));
 	}
 
+	@PreAuthorize("hasRole('USER')")
+	@PutMapping("/{projectId}/applicants/{memberId}/accept")
+	public ResponseEntity acceptApplicant(
+		@PathVariable Long projectId, @PathVariable Long memberId,
+		@AuthenticationPrincipal LoginMember member) {
 
+		projectApplicantService.manageApplicant(ManageApplicantForm.builder()
+			.projectId(projectId)
+			.applicantMemberId(memberId)
+			.projectOwnerMemberId(member.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build());
 
+		return ResponseEntity.ok().body("");
+	}
 
+	@PreAuthorize("hasRole('USER')")
+	@PutMapping("/{projectId}/applicants/{memberId}/reject")
+	public ResponseEntity rejectApplicant(
+		@PathVariable Long projectId, @PathVariable Long memberId,
+		@AuthenticationPrincipal LoginMember member) {
+
+		projectApplicantService.manageApplicant(ManageApplicantForm.builder()
+			.projectId(projectId)
+			.applicantMemberId(memberId)
+			.projectOwnerMemberId(member.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build());
+
+		return ResponseEntity.ok().body("");
+	}
+
+	@PreAuthorize("hasRole('USER') and principal.id == #memberId or hasRole('ADMIN')")
+	@DeleteMapping("/{projectId}/applicants/{memberId}")
+	public ResponseEntity deleteApplicant(
+		@PathVariable Long projectId, @PathVariable Long memberId) {
+
+		projectApplicantService.deleteApplicant(projectId, memberId);
+
+		return ResponseEntity.ok().body("");
+	}
 
 }

--- a/src/main/java/chocoteamteam/togather/dto/ManageApplicantForm.java
+++ b/src/main/java/chocoteamteam/togather/dto/ManageApplicantForm.java
@@ -1,0 +1,21 @@
+package chocoteamteam.togather.dto;
+
+import chocoteamteam.togather.type.ApplicantStatus;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ManageApplicantForm {
+
+	private Long projectId;
+	private Long applicantMemberId;
+	private Long projectOwnerMemberId;
+	private ApplicantStatus status;
+
+}

--- a/src/main/java/chocoteamteam/togather/entity/Applicant.java
+++ b/src/main/java/chocoteamteam/togather/entity/Applicant.java
@@ -47,4 +47,8 @@ public class Applicant extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private ApplicantStatus status;
 
+	public void changeStatus(ApplicantStatus status) {
+		this.status = status;
+	}
+
 }

--- a/src/main/java/chocoteamteam/togather/entity/ProjectMember.java
+++ b/src/main/java/chocoteamteam/togather/entity/ProjectMember.java
@@ -8,6 +8,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(name = "unique_member_project",
+			columnNames = {"member_id", "project_id"})
+	}
+)
 @Builder
 @Entity
 public class ProjectMember extends BaseTimeEntity {

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST,"찾을 수 없는 채팅방입니다."),
     CHATROOM_NOT_MATCHED_PROJECT(HttpStatus.BAD_REQUEST,"프로젝트에 없는 채팅방입니다."),
-    ALREADY_APPLY_PROJECT(HttpStatus.BAD_REQUEST,"이미 지원한 프로젝트입니다.");
+    ALREADY_APPLY_PROJECT(HttpStatus.BAD_REQUEST,"이미 지원한 프로젝트입니다."),
+    NOT_FOUND_APPLICANT(HttpStatus.BAD_REQUEST,"찾을 수 없는 신청자 입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
+++ b/src/main/java/chocoteamteam/togather/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST,"찾을 수 없는 채팅방입니다."),
     CHATROOM_NOT_MATCHED_PROJECT(HttpStatus.BAD_REQUEST,"프로젝트에 없는 채팅방입니다."),
     ALREADY_APPLY_PROJECT(HttpStatus.BAD_REQUEST,"이미 지원한 프로젝트입니다."),
-    NOT_FOUND_APPLICANT(HttpStatus.BAD_REQUEST,"찾을 수 없는 신청자 입니다.");
+    NOT_FOUND_APPLICANT(HttpStatus.BAD_REQUEST,"찾을 수 없는 신청자 입니다."),
+    ALREADY_CHECKED_APPLICANT(HttpStatus.BAD_REQUEST,"이미 처리된 신청자입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/ApplicantRepository.java
@@ -1,10 +1,14 @@
 package chocoteamteam.togather.repository;
 
 import chocoteamteam.togather.entity.Applicant;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ApplicantRepository extends JpaRepository<Applicant, Long>,QuerydslApplicantRepository  {
+public interface ApplicantRepository extends JpaRepository<Applicant, Long>,
+	QuerydslApplicantRepository {
 
 	boolean existsByProjectIdAndMemberId(Long projectId, Long applicantId);
+
+	Optional<Applicant> findByProjectIdAndMemberId(Long projectId, Long memberId);
 
 }

--- a/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
@@ -71,7 +71,9 @@ public class ProjectApplicantService {
 
 		Applicant applicant = findApplicant(form.getProjectId(),form.getApplicantMemberId());
 
-		// 메소드 자체를 분리해야할 듯? 왜냐하면 수락하는 순간 ProjectMember가 생성되어야함
+		if (!ApplicantStatus.WAIT.equals(applicant.getStatus())) {
+			throw new ApplicantException(ErrorCode.ALREADY_CHECKED_APPLICANT);
+		}
 
 		applicant.changeStatus(form.getStatus());
 

--- a/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
+++ b/src/main/java/chocoteamteam/togather/service/ProjectApplicantService.java
@@ -4,11 +4,13 @@ import chocoteamteam.togather.dto.ApplicantDto;
 import chocoteamteam.togather.dto.ManageApplicantForm;
 import chocoteamteam.togather.entity.Applicant;
 import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.ProjectMember;
 import chocoteamteam.togather.exception.ApplicantException;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.ProjectException;
 import chocoteamteam.togather.repository.ApplicantRepository;
 import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectMemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
 import chocoteamteam.togather.type.ApplicantStatus;
 import java.util.List;
@@ -23,6 +25,8 @@ public class ProjectApplicantService {
 	private final ProjectRepository projectRepository;
 	private final ApplicantRepository applicantRepository;
 	private final MemberRepository memberRepository;
+
+	private final ProjectMemberRepository projectMemberRepository;
 
 	@Transactional
 	public void applyForProject(Long memberId, Long projectId) {
@@ -67,7 +71,18 @@ public class ProjectApplicantService {
 
 		Applicant applicant = findApplicant(form.getProjectId(),form.getApplicantMemberId());
 
+		// 메소드 자체를 분리해야할 듯? 왜냐하면 수락하는 순간 ProjectMember가 생성되어야함
+
 		applicant.changeStatus(form.getStatus());
+
+		if (ApplicantStatus.ACCEPTED.equals(form.getStatus())) {
+			ProjectMember projectMember = ProjectMember.builder()
+				.project(projectRepository.getReferenceById(form.getProjectId()))
+				.member(memberRepository.getReferenceById(form.getApplicantMemberId()))
+				.build();
+
+			projectMemberRepository.save(projectMember);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/chocoteamteam/togather/type/ApplicantStatus.java
+++ b/src/main/java/chocoteamteam/togather/type/ApplicantStatus.java
@@ -1,6 +1,5 @@
 package chocoteamteam.togather.type;
 
 public enum ApplicantStatus {
-	WAIT,REJECTED,ACCEPTED,CANCEL
-
+	WAIT,REJECTED,ACCEPTED
 }

--- a/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
@@ -5,9 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import chocoteamteam.togather.dto.ApplicantDto;
+import chocoteamteam.togather.dto.ManageApplicantForm;
 import chocoteamteam.togather.entity.Applicant;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
@@ -21,6 +23,7 @@ import chocoteamteam.togather.type.ApplicantStatus;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,42 +47,62 @@ class ProjectApplicantServiceTest {
 	@InjectMocks
 	ProjectApplicantService projectApplicantService;
 
+	Member owner;
+	Member member;
+	Project project;
+
+	@BeforeEach
+	public void init() {
+		owner = Member.builder()
+			.id(1L)
+			.build();
+
+		project = Project.builder()
+			.id(1L)
+			.member(owner)
+			.build();
+
+		member = Member.builder()
+			.id(2L)
+			.build();
+	}
+
 	@DisplayName("프로젝트 참여 신청 성공")
 	@Test
-	void addApplcant_success() {
+	void applyForProject_success() {
 		//given
 		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(false);
 
 		given(projectRepository.getReferenceById(any()))
-			.willReturn(Project.builder().id(1L).build());
+			.willReturn(project);
 
 		given(memberRepository.getReferenceById(any()))
-			.willReturn(Member.builder().id(1L).build());
+			.willReturn(member);
 
 		ArgumentCaptor<Applicant> captor = ArgumentCaptor.forClass(Applicant.class);
 
 		//when
-		projectApplicantService.addApplicant(1L, 1L);
+		projectApplicantService.applyForProject(2L, 1L);
 
 		//then
 		verify(applicantRepository).save(captor.capture());
 
 		assertThat(captor.getValue().getStatus()).isEqualTo(ApplicantStatus.WAIT);
-		assertThat(captor.getValue().getProject().getId()).isEqualTo(1L);
-		assertThat(captor.getValue().getMember().getId()).isEqualTo(1L);
+		assertThat(captor.getValue().getProject().getId()).isEqualTo(project.getId());
+		assertThat(captor.getValue().getMember().getId()).isEqualTo(member.getId());
 	}
 
 	@DisplayName("프로젝트 참여 신청 실패 - 참여 신청 기록이 존재하는 경우")
 	@Test
-	void addApplicant_fail() {
+	void applyForProject_fail() {
 		//given
 		given(applicantRepository.existsByProjectIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(true);
 
 		//when
 		//then
-		assertThatThrownBy(() -> projectApplicantService.addApplicant(1L, 1L))
+		assertThatThrownBy(() -> projectApplicantService.applyForProject(1L, 1L))
 			.isInstanceOf(ApplicantException.class)
 			.hasMessage(ErrorCode.ALREADY_APPLY_PROJECT.getErrorMessage());
 
@@ -87,23 +110,19 @@ class ProjectApplicantServiceTest {
 
 	@DisplayName("프로젝트 신청자 목록 조회 성공")
 	@Test
-	void getApplicants_success(){
-	    //given
+	void getApplicants_success() {
+		//given
 		given(projectRepository.findById(anyLong()))
-			.willReturn(Optional.of(Project.builder()
-					.member(Member.builder()
-						.id(1L)
-						.build())
-				.build()));
+			.willReturn(Optional.of(project));
 
-		given(applicantRepository.findAllByProjectId(anyLong(),any()))
+		given(applicantRepository.findAllByProjectId(anyLong(), any()))
 			.willReturn(Arrays.asList(ApplicantDto.builder()
 				.applicantId(1L)
 				.memberId(1L)
 				.build()
 			));
 
-	    //when
+		//when
 		List<ApplicantDto> applicants = projectApplicantService.getApplicants(1L, 1L);
 
 		//then
@@ -112,20 +131,143 @@ class ProjectApplicantServiceTest {
 
 	@DisplayName("프로젝트 신청자 목록 조회 실패 - 프로젝트 관리자가 아닌 경우")
 	@Test
-	void getApplicants_fail_notMatchMemberProject(){
-	    //given
+	void getApplicants_fail_notMatchMemberProject() {
+		//given
 		given(projectRepository.findById(anyLong()))
-			.willReturn(Optional.of(Project.builder()
-					.member(Member.builder()
-						.id(1L)
-						.build())
-				.build()));
+			.willReturn(Optional.of(project));
 
-	    //when
+		//when
 		//then
 		assertThatThrownBy(() -> projectApplicantService.getApplicants(1L, 2L))
 			.isInstanceOf(ProjectException.class)
 			.hasMessage(ErrorCode.NOT_MATCH_MEMBER_PROJECT.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 신청자 관리 성공")
+	@Test
+	void manageApplicant_success() {
+		//given
+		Applicant applicant = Applicant.builder()
+			.id(1L)
+			.status(ApplicantStatus.WAIT)
+			.build();
+
+		ManageApplicantForm form = ManageApplicantForm.builder()
+			.projectId(project.getId())
+			.applicantMemberId(member.getId())
+			.projectOwnerMemberId(owner.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build();
+
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(project));
+
+		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(Optional.of(applicant));
+
+		//when
+		projectApplicantService.manageApplicant(form);
+
+		//then
+		assertThat(applicant.getStatus()).isEqualTo(form.getStatus());
+	}
+
+	@DisplayName("프로젝트 신청자 관리 실패 - 프로젝트가 없는 경우")
+	@Test
+	void manageApplicant_fail_notFoundProject() {
+		//given
+		ManageApplicantForm form = ManageApplicantForm.builder()
+			.projectId(project.getId())
+			.applicantMemberId(member.getId())
+			.projectOwnerMemberId(owner.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build();
+
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.empty());
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.manageApplicant(form))
+			.isInstanceOf(ProjectException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_PROJECT.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 신청자 관리 실패 - 프로젝트에 대한 권한이 없는 경우")
+	@Test
+	void manageApplicant_fail_notMatchMemberProject() {
+		//given
+		ManageApplicantForm form = ManageApplicantForm.builder()
+			.projectId(project.getId())
+			.applicantMemberId(member.getId())
+			.projectOwnerMemberId(3L)
+			.status(ApplicantStatus.ACCEPTED)
+			.build();
+
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(project));
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.manageApplicant(form))
+			.isInstanceOf(ProjectException.class)
+			.hasMessage(ErrorCode.NOT_MATCH_MEMBER_PROJECT.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 신청자 관리 실패 - 신청자를 찾을 수 없는 경우")
+	@Test
+	void manageApplicant_fail_notFoundApplicant() {
+		//given
+		ManageApplicantForm form = ManageApplicantForm.builder()
+			.projectId(project.getId())
+			.applicantMemberId(member.getId())
+			.projectOwnerMemberId(owner.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build();
+
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(project));
+
+		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(Optional.empty());
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.manageApplicant(form))
+			.isInstanceOf(ApplicantException.class)
+			.hasMessage(ErrorCode.NOT_FOUND_APPLICANT.getErrorMessage());
+	}
+
+	@DisplayName("프로젝트 신청자 삭제 성공")
+	@Test
+	void deleteApplicant_success() {
+		//given
+		Applicant applicant = Applicant.builder()
+			.id(1L)
+			.status(ApplicantStatus.WAIT)
+			.build();
+
+		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(Optional.of(applicant));
+
+		//when
+		projectApplicantService.deleteApplicant(1L,1L);
+
+		//then
+		verify(applicantRepository).delete(any());
+	}
+
+	@DisplayName("프로젝트 신청자 삭제 실패 - 신청자가 존재하지 않는 경우")
+	@Test
+	void deleteApplicant_fail() {
+		//given
+		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(Optional.empty());
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.deleteApplicant(1L, 1L));
+
 	}
 
 

--- a/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
@@ -257,6 +257,35 @@ class ProjectApplicantServiceTest {
 			.hasMessage(ErrorCode.NOT_FOUND_APPLICANT.getErrorMessage());
 	}
 
+	@DisplayName("프로젝트 신청자 관리 실패 - WAIT이 아닌 경우")
+	@Test
+	void manageApplicant_fail_alreadyApplyProject(){
+		//given
+		Applicant applicant = Applicant.builder()
+			.id(1L)
+			.status(ApplicantStatus.REJECTED)
+			.build();
+
+		ManageApplicantForm form = ManageApplicantForm.builder()
+			.projectId(project.getId())
+			.applicantMemberId(member.getId())
+			.projectOwnerMemberId(owner.getId())
+			.status(ApplicantStatus.ACCEPTED)
+			.build();
+
+		given(projectRepository.findById(anyLong()))
+			.willReturn(Optional.of(project));
+
+		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
+			.willReturn(Optional.of(applicant));
+
+		//when
+		//then
+		assertThatThrownBy(() -> projectApplicantService.manageApplicant(form))
+			.isInstanceOf(ApplicantException.class)
+			.hasMessage(ErrorCode.ALREADY_CHECKED_APPLICANT.getErrorMessage());
+	}
+
 	@DisplayName("프로젝트 신청자 삭제 성공")
 	@Test
 	void deleteApplicant_success() {
@@ -270,7 +299,7 @@ class ProjectApplicantServiceTest {
 			.willReturn(Optional.of(applicant));
 
 		//when
-		projectApplicantService.deleteApplicant(1L,1L);
+		projectApplicantService.deleteApplicant(1L, 1L);
 
 		//then
 		verify(applicantRepository).delete(any());
@@ -288,8 +317,6 @@ class ProjectApplicantServiceTest {
 		assertThatThrownBy(() -> projectApplicantService.deleteApplicant(1L, 1L));
 
 	}
-
-
 
 
 }

--- a/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/ProjectApplicantServiceTest.java
@@ -13,11 +13,13 @@ import chocoteamteam.togather.dto.ManageApplicantForm;
 import chocoteamteam.togather.entity.Applicant;
 import chocoteamteam.togather.entity.Member;
 import chocoteamteam.togather.entity.Project;
+import chocoteamteam.togather.entity.ProjectMember;
 import chocoteamteam.togather.exception.ApplicantException;
 import chocoteamteam.togather.exception.ErrorCode;
 import chocoteamteam.togather.exception.ProjectException;
 import chocoteamteam.togather.repository.ApplicantRepository;
 import chocoteamteam.togather.repository.MemberRepository;
+import chocoteamteam.togather.repository.ProjectMemberRepository;
 import chocoteamteam.togather.repository.ProjectRepository;
 import chocoteamteam.togather.type.ApplicantStatus;
 import java.util.Arrays;
@@ -43,6 +45,9 @@ class ProjectApplicantServiceTest {
 
 	@Mock
 	MemberRepository memberRepository;
+
+	@Mock
+	ProjectMemberRepository projectMemberRepository;
 
 	@InjectMocks
 	ProjectApplicantService projectApplicantService;
@@ -159,11 +164,25 @@ class ProjectApplicantServiceTest {
 			.status(ApplicantStatus.ACCEPTED)
 			.build();
 
+		ProjectMember projectMember = ProjectMember.builder()
+			.member(member)
+			.project(project)
+			.build();
+
 		given(projectRepository.findById(anyLong()))
 			.willReturn(Optional.of(project));
 
 		given(applicantRepository.findByProjectIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(Optional.of(applicant));
+
+		given(projectRepository.getReferenceById(anyLong()))
+			.willReturn(project);
+
+		given(memberRepository.getReferenceById(anyLong()))
+			.willReturn(member);
+
+		given(projectMemberRepository.save(any()))
+			.willReturn(projectMember);
 
 		//when
 		projectApplicantService.manageApplicant(form);


### PR DESCRIPTION
**개요**

- #60 
- feat: 신청 수락,거절 API 및 신청 삭제 API 추가

**타입** 
- [x]  feat : 새로운 기능 추가


**작업 사항**
- 신청 수락,거절 API 추가 -> 수락, 거절을 따로 분리했습니다.
- 신청자 삭제 API 추가 -> 신청 취소 때 사용하면 될 듯 합니다.

**Test**🧪
- 테스트 코드를 참고해주세요!

