### PR TITLE
feat: 회원 닉네임 중복 체크 api 

### DIFF
--- a/src/main/java/chocoteamteam/togather/controller/MemberController.java
+++ b/src/main/java/chocoteamteam/togather/controller/MemberController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Member", description = "회원 관련 API")
@@ -63,6 +64,15 @@ public class MemberController {
 		memberService.modify(memberId, request, loginMember.getId());
 		return ResponseEntity.ok().body("");
 	}
+
+    @Operation(
+        summary = "회원 닉네임 중복 검사 Api", description = "회원의 닉네임이 중복되는지 확인할 수 있습니다.",
+        tags = {"Member"}
+    )
+    @GetMapping("/nickname/exist")
+    public ResponseEntity<Boolean> existNickname(@RequestParam String nickname) {
+        return ResponseEntity.ok(memberService.existNickname(nickname));
+    }
 
 }
 

--- a/src/main/java/chocoteamteam/togather/dto/ChatMessageDto.java
+++ b/src/main/java/chocoteamteam/togather/dto/ChatMessageDto.java
@@ -15,6 +15,6 @@ public class ChatMessageDto {
 	private String nickname;
 	private String profileImage;
 	private String message;
-	private LocalDateTime time;
+	private LocalDateTime sendTime;
 
 }

--- a/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
+++ b/src/main/java/chocoteamteam/togather/repository/impl/QuerydslChatRepository.java
@@ -29,7 +29,7 @@ public class QuerydslChatRepository {
 					member.nickname.as("nickname"),
 					member.profileImage.as("profileImage"),
 					chatMessage.message.as("message"),
-					chatMessage.createdAt.as("time")
+					chatMessage.createdAt.as("sendTime")
 				)).from(chatMessage)
 			.innerJoin(chatMessage.sender, member)
 			.where(chatMessage.chatRoom.id.eq(chatRoomId))

--- a/src/main/java/chocoteamteam/togather/service/MemberService.java
+++ b/src/main/java/chocoteamteam/togather/service/MemberService.java
@@ -145,4 +145,7 @@ public class MemberService {
         }
     }
 
+    public boolean existNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
 }

--- a/src/test/java/chocoteamteam/togather/service/MemberServiceTest.java
+++ b/src/test/java/chocoteamteam/togather/service/MemberServiceTest.java
@@ -261,4 +261,17 @@ class MemberServiceTest {
             .hasMessage(ErrorCode.NOT_FOUND_MEMBER.getErrorMessage());
     }
 
+    @DisplayName("닉네임 중복 검사 - 성공")
+    @Test
+    void existNickname_success(){
+        // given
+        given(memberRepository.existsByNickname(any())).willReturn(true);
+
+        // when
+        boolean response = memberService.existNickname("test");
+
+        // then
+        assertThat(response).isTrue();
+    }
+
 }


### PR DESCRIPTION
**개요**
- 회원 닉네임 중복 체크 api 추가, chatmessageDto 필드명 수정

**타입** 
- [x]  feat : 새로운 기능 추가
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)

**작업 사항**
- 회원이 자신의 정보 수정 혹은 가입할 때 닉네임이 중복되는지 체크할 수 있는 api 추가
- chatmessageDto의 필드 time을 sendTime으로 변경했습니다.

**Test**🧪
- 닉네임을 입력 받아 boolean 값으로 응답하는지 확인했습니다.

